### PR TITLE
Some edition forms titles were escaped twice

### DIFF
--- a/creme/billing/templates/billing/form/edit.html
+++ b/creme/billing/templates/billing/form/edit.html
@@ -1,6 +1,7 @@
 {% extends 'creme_core/generics/blockform/edit.html' %}
-{% load i18n %}
+{# {% load i18n %} #}
 
-{% block content %}{% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %}
-    {% include 'billing/form/base.html' with icon_name='edit' title=form_title %}
+{% block content %}{# {% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %} #}
+{#    {% include 'billing/form/base.html' with icon_name='edit' title=form_title %} #}
+    {% include 'billing/form/base.html' with icon_name='edit' %}
 {% endblock %}

--- a/creme/creme_core/templates/creme_core/forms/entity-filter.html
+++ b/creme/creme_core/templates/creme_core/forms/entity-filter.html
@@ -7,9 +7,9 @@
 {% trans 'Filter' context 'creme_core-noun' as icon_label %}
     {% if not form.instance.pk %}
         {% blocktrans with ctype=form.instance.entity_type asvar form_title %}Create a filter for «{{ctype}}»{% endblocktrans %}
-        {% include 'creme_core/generics/blockform/base.html' with icon_name='filter' icon_label=icon_label title=form_title %}
+        {% include 'creme_core/generics/blockform/base.html' with icon_name='filter' icon_label=icon_label title=form_title|safe %}
     {% else %}
         {% blocktrans with filter=form.instance asvar form_title %}Edit the filter «{{filter}}»{% endblocktrans %}
-        {% include 'creme_core/generics/blockform/base.html' with icon_name='filter' icon_label=icon_label title=form_title %}
+        {% include 'creme_core/generics/blockform/base.html' with icon_name='filter' icon_label=icon_label title=form_title|safe %}
     {% endif %}
 {% endblock %}

--- a/creme/creme_core/templates/creme_core/forms/header-filter.html
+++ b/creme/creme_core/templates/creme_core/forms/header-filter.html
@@ -6,9 +6,9 @@
 {% block content %}
     {% if not form.instance.pk %}
         {% blocktrans with ctype=form.instance.entity_type asvar form_title %}Create a view of list for «{{ctype}}»{% endblocktrans %}
-        {% include 'creme_core/generics/blockform/base.html' with icon_name='header_filter' icon_label=_('View of list') title=form_title %}
+        {% include 'creme_core/generics/blockform/base.html' with icon_name='header_filter' icon_label=_('View of list') title=form_title|safe %}
     {% else %}
         {% blocktrans with view=form.instance asvar form_title %}Edit the view of list «{{view}}»{% endblocktrans %}
-        {% include 'creme_core/generics/blockform/base.html' with icon_name='header_filter' icon_label=_('View of list') title=form_title %}
+        {% include 'creme_core/generics/blockform/base.html' with icon_name='header_filter' icon_label=_('View of list') title=form_title|safe %}
     {% endif %}
 {% endblock %}

--- a/creme/creme_core/templates/creme_core/generics/blockform/edit-wizard.html
+++ b/creme/creme_core/templates/creme_core/generics/blockform/edit-wizard.html
@@ -14,7 +14,7 @@
 {% block content %}
     {% with icon_name='edit' icon_label=_('Edit') submit_label=submit_label|default:_('Save the modifications') %}
         {% if not title %}{% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %}
-            {% include 'creme_core/generics/blockform/base.html' with title=form_title %}
+            {% include 'creme_core/generics/blockform/base.html' with title=form_title|safe %}
         {% else %}
             {% include 'creme_core/generics/blockform/base-wizard.html' %}
         {% endif %}

--- a/creme/creme_core/templates/creme_core/generics/blockform/edit.html
+++ b/creme/creme_core/templates/creme_core/generics/blockform/edit.html
@@ -14,7 +14,7 @@
 {% block content %}
     {% with icon_name='edit' icon_label=_('Edit') submit_label=submit_label|default:_('Save the modifications') %}
         {% if not title %}{% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %}
-            {% include 'creme_core/generics/blockform/base.html' with title=form_title %}
+            {% include 'creme_core/generics/blockform/base.html' with title=form_title|safe %}
         {% else %}
             {% include 'creme_core/generics/blockform/base.html' %}
         {% endif %}

--- a/creme/creme_core/templates/creme_core/generics/form/edit.html
+++ b/creme/creme_core/templates/creme_core/generics/form/edit.html
@@ -14,7 +14,7 @@
 {% block content %}
     {% with icon_name='edit' icon_label=_('Edit') submit_label=submit_label|default:_('Save the modifications') %}
         {% if not title %}{% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %}
-            {% include 'creme_core/generics/form/base.html' with title=form_title %}
+            {% include 'creme_core/generics/form/base.html' with title=form_title|safe %}
         {% else %}
             {% include 'creme_core/generics/form/base.html' %}
         {% endif %}

--- a/creme/persons/templates/persons/edit_contact_form.html
+++ b/creme/persons/templates/persons/edit_contact_form.html
@@ -1,6 +1,7 @@
 {% extends 'creme_core/generics/blockform/edit.html' %}
-{% load i18n %}
+{# {% load i18n %} #}
 
-{% block content %}{% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %}
-    {% include 'persons/frags/contact_form_content.html' with icon_name='edit' title=form_title %}
+{% block content %}{# {% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %} #}
+{#    {% include 'persons/frags/contact_form_content.html' with icon_name='edit' title=form_title %} #}
+    {% include 'persons/frags/contact_form_content.html' with icon_name='edit' %}
 {% endblock %}

--- a/creme/persons/templates/persons/edit_organisation_form.html
+++ b/creme/persons/templates/persons/edit_organisation_form.html
@@ -1,6 +1,7 @@
 {% extends 'creme_core/generics/blockform/edit.html' %}
-{% load i18n %}
+{# {% load i18n %} #}
 
-{% block content %}{% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %}
-    {% include 'persons/frags/organisation_form_content.html' with icon_name='edit' title=form_title %}
+{% block content %}{#{% blocktrans asvar form_title %}Edit «{{object}}»{% endblocktrans %}#}
+{#    {% include 'persons/frags/organisation_form_content.html' with icon_name='edit' title=form_title %} #}
+    {% include 'persons/frags/organisation_form_content.html' with icon_name='edit' %}
 {% endblock %}


### PR DESCRIPTION
So quote chars were replaced by HTML crap.

It's because {% bloctrans .. asvar .. %} seems to not mark variable as safe.