### PR TITLE
Continuous integration improvement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
             - creme_crm
 
       - create-virtualenv
-      - run: pip install -e .[dev,mysql,pgsql,graphs]
+      - run: pip install -U -e .[dev,mysql,pgsql,graphs]
       - run: pip list --outdated
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
         environment:
           MYSQL_ROOT_PASSWORD: creme
           MYSQL_DATABASE: cremecrm
+    resource_class: large
     steps:
       - checkout
 
@@ -115,7 +116,7 @@ jobs:
       - run: python creme/manage.py migrate
       - run: python creme/manage.py creme_populate
       - run: python creme/manage.py generatemedia
-      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=6
+      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
       - run: coverage combine
       - run: coverage html
       - store_artifacts:
@@ -130,6 +131,7 @@ jobs:
           POSTGRES_USER: creme
           POSTGRES_PASSWORD: creme
           POSTGRES_DB: cremecrm
+    resource_class: large
     steps:
       - checkout
 
@@ -156,6 +158,7 @@ jobs:
   tests-sqlite3:
     docker:
       - image: circleci/python:3.7-browsers
+    resource_class: large
     steps:
       - checkout
 

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,6 @@ isort-check:
 	isort creme/ --check --diff --atomic
 
 
-
 ## Sort the Python imports with isort
 .PHONY: isort-fix
 isort-fix:
@@ -135,9 +134,14 @@ flake8:
 	flake8 creme
 
 
-## Run all the Python linters
+## Run all the Python linter checks
 .PHONY: lint
 lint: isort-check flake8
+
+
+## Run all the Python linter fixes
+.PHONY: format
+format: isort-fix
 
 
 ## Print some Django settings

--- a/Makefile
+++ b/Makefile
@@ -119,14 +119,14 @@ eslint:
 ## Validates the Python imports with isort
 .PHONY: isort-check
 isort-check:
-	isort -rc creme/ --check --diff --atomic
+	isort creme/ --check --diff --atomic
 
 
 
 ## Sort the Python imports with isort
 .PHONY: isort-fix
 isort-fix:
-	isort -rc creme/ --atomic
+	isort creme/ --atomic
 
 
 ## Validates the Python code with flake8

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ clean:
 	find . -name '*.pyo' -delete
 	find . -name '__pycache__' -delete
 	rm -rf *.egg
-	rm -rf *.egg-info
 	rm -rf ./build
 	rm -rf ./package
 	rm -rf ./dist

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-cov:
 	@echo "file://$(shell pwd)/artifacts/coverage_html/index.html"
 
 ## Cleanup karma coverage html output
-.PHONY: karma
+.PHONY: karma-clean
 karma-clean:
 	rm -f artifacts/karma_coverage/html/static/*.html
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ dev=
     coverage ~=5.2.1
     flake8 ~=3.8.3
     isort ~=5.5.3
+    ipython ~=7.18.1
     parameterized ~=0.7.4
     tblib ~=1.7.0
     django-extensions ~=3.0.9


### PR DESCRIPTION
CircleCI: Update the python dependencies fetched from cache
Makefile: Remove the deprecated -rc isort argument
Makefile: compatibility - Add a format target
Dependencies: add ipython to the dev environment
Makefile: Fix karma-clean .PHONY 
Makefile: Do not remove creme.egg-info
CircleCI: use large ressource class for python tests