### PR TITLE
The "activities" views 'RelatedActivityCreation' has been improved...

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -410,7 +410,9 @@
                 - The method 'models.Document.get_dl_url()' has been removed ; use the method 'get_download_absolute_url()' instead.
             * Activities :
                 - The view named "activities__create_activity_popup" now accepts "start" & "end" arguments in ISO8601.
-                - The ending date returned by the view named "activities__calendars_activities" has changed : "end day + 1 at 00:00" instead of "end day at 23:59"
+                - The ending date returned by the view named "activities__calendars_activities" has changed : "end day + 1 at 00:00" instead of "end day at 23:59".
+                - The class-based view 'views.activity.RelatedActivityCreation' does not pass special 'kwargs' arguments to its form any more
+                  (classical 'get_initial()' method is used instead).
                 - In JavaScript, all methods of 'creme.activities.calendar' have been removed & replaced by 'creme.activities.CalendarController'.
             * Emails :
                 - 'In 'models' :

--- a/creme/activities/forms/activity.py
+++ b/creme/activities/forms/activity.py
@@ -19,6 +19,7 @@
 ################################################################################
 
 import logging
+import warnings
 from datetime import datetime, time, timedelta
 from functools import partial
 
@@ -500,6 +501,8 @@ class ActivityCreateForm(_ActivityCreateForm):
 
 class RelatedActivityCreateForm(ActivityCreateForm):
     def __init__(self, related_entity, relation_type_id, *args, **kwargs):
+        warnings.warn('RelatedActivityCreateForm is deprecated.', DeprecationWarning)
+
         super().__init__(*args, **kwargs)
 
         if relation_type_id == constants.REL_SUB_PART_2_ACTIVITY:


### PR DESCRIPTION
… to use the regular creation form (by using the "initial" system).

So 'RelatedActivityCreateForm' has been deprecated.