### PR TITLE
Improve mediagenerator error output.

### DIFF
--- a/mediagenerator/filters/closure.py
+++ b/mediagenerator/filters/closure.py
@@ -1,8 +1,12 @@
+from json import loads as parse_json
+
 from django.conf import settings
+
 from mediagenerator.generators.bundles.base import SubProcessFilter
 
 COMPILATION_LEVEL = getattr(settings, 'CLOSURE_COMPILATION_LEVEL',
                             'SIMPLE_OPTIMIZATIONS')
+
 
 class Closure(SubProcessFilter):
     def __init__(self, **kwargs):
@@ -12,21 +16,42 @@ class Closure(SubProcessFilter):
             f'Closure only supports compilation to js. '
             f'The parent filter expects "{self.filetype}".')
 
+    def parse_errors(self, output):
+        # ignore the first line which is not json (WTF !)
+        errors = parse_json(output.splitlines()[1])
+
+        return [
+            (e['line'], e['column'], e['description'])
+            for e in errors if e['level'] == 'error'
+        ]
+
     def get_output(self, variation):
         # We import this here, so App Engine Helper users don't get import
         # errors.
         compressor = settings.CLOSURE_COMPILER_PATH
 
-        for input in self.get_input(variation):
+        for source in self.get_input(variation):
             try:
                 yield self.run_process([
-                    'java', '-jar', compressor, '--charset', 'utf-8', '--compilation_level', self.compilation_level,
-                ], input=input)
+                    'java', '-jar', compressor,
+                    '--charset', 'utf-8',
+                    '--compilation_level', self.compilation_level,
+                    '--error_format', 'JSON'
+                ], input=source)
+            except SubProcessFilter.ProcessError as e:
+                errors = self.parse_errors(e.stderr)
+
+                if errors:
+                    message = self.format_lint_errors(errors, source)
+                    raise ValueError(message)
+                else:
+                    message = f"The Closure compiler has returned an error. {e.stderr}"
+
             except Exception as e:
                 raise ValueError(
                     "Failed to execute Java VM or Closure. "
                     "Please make sure that you have installed Java "
                     "and that it's in your PATH and that you've configured "
                     "CLOSURE_COMPILER_PATH in your settings correctly.\n"
-                    "Error was: {}".format(e)
+                    f"Error was: {e}"
                 )

--- a/mediagenerator/filters/yuicompressor.py
+++ b/mediagenerator/filters/yuicompressor.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf import settings
 
 from mediagenerator.generators.bundles.base import SubProcessFilter
@@ -10,18 +12,41 @@ class YUICompressor(SubProcessFilter):
             f'YUICompressor only supports compilation to css and js. '
             f'The parent filter expects "{self.filetype}".')
 
+    def parse_errors(self, e):
+        pattern = re.compile(
+            r'^\[ERROR\]\s+(?P<line>[0-9]+):(?P<col>[0-9]+):(?P<message>.+)\n',
+            re.MULTILINE
+        )
+        errors = pattern.findall(str(e))
+
+        # The last error is the java exception raised by compressor, so ignore it
+        return [
+            (int(index), int(col), message) for index, col, message in errors[:-1]
+        ]
+
     def get_output(self, variation):
-        for input in self.get_input(variation):
+        for source in self.get_input(variation):
             try:
                 compressor = settings.YUICOMPRESSOR_PATH
                 yield self.run_process([
-                    'java', '-jar', compressor, '--charset', 'utf-8', '--type', self.filetype
-                ], input=input)
+                    'java', '-jar', compressor,
+                    '--charset', 'utf-8',
+                    '--type', self.filetype
+                ], input=source)
+            except SubProcessFilter.ProcessError as e:
+                errors = self.parse_errors(e.stderr)
+
+                if errors:
+                    message = self.format_lint_errors(errors, source)
+                else:
+                    f"The YUI Compressor has returned an error. {e.stderr}"
+
+                raise ValueError(message)
             except Exception as e:
                 raise ValueError(
                     "Failed to execute Java VM or yuicompressor. "
                     "Please make sure that you have installed Java "
                     "and that it's in your PATH and that you've configured "
                     "YUICOMPRESSOR_PATH in your settings correctly.\n"
-                    "Error was: {}".format(e)
+                    "{}".format(e)
                 )


### PR DESCRIPTION
The purpose of this PR is displaying some context for each error like a `diff` output.

By default `yuicompressor` and `closure` just output line & column numbers of the HUGE concatened files and not useful at all.
I got this issue during the backport of the upgrade of tinymce on creme 2.1.

yuicompressor does not support usage of the keyword 'defaut' and displays
```
[ERROR] 75175:40:il manque un nom après un opérateur '.'
```

Now we have something a bit more interesting
```
ValueError: ______________________________________________
 75173:     UnzonedRange.prototype.getStart = function () {
 75174:         if (this.startMs != null) {
 75175:             return moment_ext_1.default.utc(this.startMs).stripZone();
                                                ^__ il manque un nom après un opérateur '.'

 75176:         }
 75177:         return null;

```
