### PR TITLE
In merge forms, mark HTML inputs as required

### DIFF
--- a/creme/creme_core/forms/merge.py
+++ b/creme/creme_core/forms/merge.py
@@ -95,6 +95,7 @@ class MergeWidget(Widget):
             attrs={
                 'id': f'{id_attr}_merged',
                 'class': 'merge_result',
+                'required': attrs.get('required', False),
             },
         )['widget']
         widget_cxt['second'] = get_sub_context(


### PR DESCRIPTION
In merge forms, the result inputs were not marked as required in HTML when they should.