### PR TITLE
Fix CircleCI jobs for javascript linting & tests

### DIFF
--- a/.circleci/.karma.conf.js
+++ b/.circleci/.karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function(config) {
 
     config.set({
         concurrency: 2,
-        basePath: process.cwd(),
+        basePath: '../',
         browserConsoleLogOptions: {
             level: "critical",
             terminal: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ commands:
       - run: touch << pipeline.parameters.instance_directory >>/__init__.py
       - run: mkdir << pipeline.parameters.instance_directory >>/media
       - run: mkdir << pipeline.parameters.instance_directory >>/media/static
+      # Not really useful because unit tests override with a sub-folder in /tmp/
       - run: mkdir << pipeline.parameters.instance_directory >>/media/upload
       - run: cp << pipeline.parameters.source_path >>/.circleci/circleci_settings.py << pipeline.parameters.instance_directory >>/settings.py
 
@@ -98,11 +99,9 @@ commands:
         default: 'sqlite3_settings'
     steps:
       - run: cp << pipeline.parameters.source_path >>/.circleci/<< parameters.local_settings >>.py << pipeline.parameters.instance_directory >>/local_settings.py
-      - run:
-          command: |
-            creme migrate --settings=<< pipeline.parameters.instance_directory >>.settings
-            creme creme_populate --settings=<< pipeline.parameters.instance_directory >>.settings
-      - setup-creme-statics
+      - run: creme migrate --settings=<< pipeline.parameters.instance_directory >>.settings
+      - run: creme creme_populate --settings=<< pipeline.parameters.instance_directory >>.settings
+      - run: creme generatemedia --settings=<< pipeline.parameters.instance_directory >>.settings
 
   run-creme-unit-tests:
     description: Run Creme unit tests
@@ -188,6 +187,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
+      - create-creme-project
       - setup-creme-unit-tests:
           local_settings: 'mysql_settings'
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
@@ -223,6 +223,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
+      - create-creme-project
       - setup-creme-unit-tests:
           local_settings: 'pgsql_settings'
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
@@ -250,6 +251,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
+      - create-creme-project
       - setup-creme-unit-tests
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
@@ -277,6 +279,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
+      - create-creme-project
       - setup-creme-unit-tests
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
@@ -304,6 +307,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
+      - create-creme-project
       - setup-creme-unit-tests
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
@@ -331,6 +335,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
+      - create-creme-project
       - setup-creme-unit-tests
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
@@ -386,12 +391,15 @@ jobs:
       - create-creme-project
       - setup-creme-statics
       - install-node-env
-      # TODO: fix (problems with static paths media hard-coded (see .karma.conf.js)
-      - run: make karma-ci
-      # - run:
-      #     name: Karma Tests
-      #     working_directory: << pipeline.parameters.instance_directory >>
-      #     command: node_modules/.bin/karma start << pipeline.parameters.source_path >>/.circleci/.karma.conf.js
+      - run:
+          name: Karma Tests
+          working_directory: << pipeline.parameters.instance_directory >>
+          command: node_modules/.bin/karma start << pipeline.parameters.source_path >>/.circleci/.karma.conf.js
+          environment:
+              KARMA_DJANGOSTATICS: ../project/<< pipeline.parameters.instance_directory >>/media/static
+              KARMA_COVERAGEOUTPUT: artifacts/karma_coverage
+      - store_artifacts:
+          path: artifacts/karma_coverage
 
 
 workflows:
@@ -399,10 +407,9 @@ workflows:
   build:
     jobs:
       - javascript-lint
-# TODO: uncomment & fix
-#      - javascript-tests:
-#          requires:
-#            - javascript-lint
+      - javascript-tests:
+          requires:
+            - javascript-lint
       - python36-lint-isort
       - python36-lint-flake8
       - python36-tests-sqlite3:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,24 +54,55 @@ commands:
           key: << parameters.python >>-creme_crm-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
           paths: "~/venv"
 
+  install-node-env:
+    steps:
+      - restore_cache:
+          key: node-dependencies-{{ checksum "<< pipeline.parameters.source_path >>/package-lock.json" }}
+
+      - run: cp << pipeline.parameters.source_path >>/package*.json << pipeline.parameters.instance_directory >>
+      - run:
+          name: Installing NodeJS
+          working_directory: << pipeline.parameters.instance_directory >>
+          command: npm install && npm run eslint-install
+          environment:
+            ESLINT_CREME_PLUGINS: "<< pipeline.parameters.source_path >>/creme/static/utils/eslint/"
+      - run:
+          working_directory: << pipeline.parameters.instance_directory >>
+          command: npm list
+
+      - save_cache:
+          key: node-dependencies-{{ checksum "<< pipeline.parameters.source_path >>/package-lock.json" }}
+          paths:
+            - << pipeline.parameters.instance_directory >>/node_modules
+
   create-creme-project:
     description: Create Creme project
-    parameters:
-      local_settings:
-        type: string
-        default: 'sqlite3_settings'
     steps:
       - run: mkdir << pipeline.parameters.instance_directory >>
       - run: touch << pipeline.parameters.instance_directory >>/__init__.py
       - run: mkdir << pipeline.parameters.instance_directory >>/media
       - run: mkdir << pipeline.parameters.instance_directory >>/media/static
-      # Not really useful because unit tests override with a sub-folder in /tmp/
       - run: mkdir << pipeline.parameters.instance_directory >>/media/upload
       - run: cp << pipeline.parameters.source_path >>/.circleci/circleci_settings.py << pipeline.parameters.instance_directory >>/settings.py
-      - run: cp << pipeline.parameters.source_path >>/.circleci/<< parameters.local_settings >>.py << pipeline.parameters.instance_directory >>/local_settings.py
-      - run: creme migrate --settings=<< pipeline.parameters.instance_directory >>.settings
-      - run: creme creme_populate --settings=<< pipeline.parameters.instance_directory >>.settings
+
+  setup-creme-statics:
+    description: Setup Creme static resources
+    steps:
       - run: creme generatemedia --settings=<< pipeline.parameters.instance_directory >>.settings
+
+  setup-creme-unit-tests:
+    description: Setup Creme database
+    parameters:
+      local_settings:
+        type: string
+        default: 'sqlite3_settings'
+    steps:
+      - run: cp << pipeline.parameters.source_path >>/.circleci/<< parameters.local_settings >>.py << pipeline.parameters.instance_directory >>/local_settings.py
+      - run:
+          command: |
+            creme migrate --settings=<< pipeline.parameters.instance_directory >>.settings
+            creme creme_populate --settings=<< pipeline.parameters.instance_directory >>.settings
+      - setup-creme-statics
 
   run-creme-unit-tests:
     description: Run Creme unit tests
@@ -84,29 +115,6 @@ commands:
       - store_artifacts:
           # NB: see .circleci/circleci_coverage.ini
           path: artifacts/coverage_html
-
-  install-node-env:
-    steps:
-      - restore_cache:
-          key: node-dependencies-{{ checksum "package-lock.json" }}
-          # TODO:
-          # key: node-dependencies-{{ checksum "<< pipeline.parameters.source_path >>/package-lock.json" }}
-
-      - run: npm install
-      # TODO (what about package.json?):
-      # - run:
-      #     name: Installing NodeJS
-      #     working_directory: << pipeline.parameters.instance_directory >>
-      #     command: npm install
-
-      - save_cache:
-          key: node-dependencies-{{ checksum "package-lock.json" }}
-          # TODO
-          # key: node-dependencies-{{ checksum "<< pipeline.parameters.source_path >>/package-lock.json" }}
-          paths:
-            - node_modules
-            # TODO:
-            # - << pipeline.parameters.instance_directory >>/node_modules
 
   setup-locale:
     description: "Locale: Setup"
@@ -180,7 +188,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
-      - create-creme-project:
+      - setup-creme-unit-tests:
           local_settings: 'mysql_settings'
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
@@ -215,7 +223,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
-      - create-creme-project:
+      - setup-creme-unit-tests:
           local_settings: 'pgsql_settings'
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
@@ -242,7 +250,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
-      - create-creme-project
+      - setup-creme-unit-tests
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
 #      - run: coverage html
@@ -269,7 +277,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
-      - create-creme-project
+      - setup-creme-unit-tests
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
 #      - run: coverage html
@@ -296,7 +304,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
-      - create-creme-project
+      - setup-creme-unit-tests
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
 #      - run: coverage html
@@ -323,8 +331,7 @@ jobs:
 #      - run: python creme/manage.py migrate
 #      - run: python creme/manage.py creme_populate
 #      - run: python creme/manage.py generatemedia
-      - create-creme-project:
-          local_settings: 'sqlite3_settings'
+      - setup-creme-unit-tests
 #      - run: COVERAGE_PROCESS_START=setup.cfg coverage run --source creme/ creme/manage.py test --noinput --parallel=8
 #      - run: coverage combine
 #      - run: coverage html
@@ -337,24 +344,47 @@ jobs:
     docker:
      - image: circleci/python:3.6-node-browsers
     steps:
-#      - checkout
       - checkout-creme
+      - install-py-dev-env:
+          python: "python3.6"
+      - create-creme-project
+      - setup-creme-statics
       - install-node-env
-#      - run: make eslint
-      - run: make -C << pipeline.parameters.source_path >> eslint
+      - run: cp << pipeline.parameters.source_path >>/.eslint* << pipeline.parameters.instance_directory >>
+      - run:
+          name: Javascript linting
+          working_directory: << pipeline.parameters.instance_directory >>
+          command: |
+              find << pipeline.parameters.source_path >>/creme -iname *.js | xargs --no-run-if-empty \
+                  node_modules/.bin/eslint \
+                  --no-eslintrc \
+                  --config .eslintrc \
+                  --ignore-path .eslintignore \
+                  --format stylish
+      - run:
+          name: Template javascript linting
+          working_directory: << pipeline.parameters.instance_directory >>
+          command: |
+              find << pipeline.parameters.source_path >>/creme -iname *.html | xargs --no-run-if-empty \
+                  node_modules/.bin/eslint \
+                  --no-eslintrc \
+                  --config .eslintrc \
+                  --ignore-path .eslintignore \
+                  --plugin template \
+                  --rule 'template/no-template-branch: 2' \
+                  --global '____' \
+                  --format stylish
 
   javascript-tests:
     docker:
      - image: circleci/python:3.6-node-browsers
     steps:
-#      - checkout
       - checkout-creme
       - install-creme-system-packages
       - install-py-dev-env:
           python: "python3.6"
-#      - run: cp ~/project/.circleci/circleci_settings.py creme/project_settings.py
-#      - run: python creme/manage.py generatemedia
       - create-creme-project
+      - setup-creme-statics
       - install-node-env
       # TODO: fix (problems with static paths media hard-coded (see .karma.conf.js)
       - run: make karma-ci
@@ -368,8 +398,8 @@ workflows:
   version: 2
   build:
     jobs:
+      - javascript-lint
 # TODO: uncomment & fix
-#      - javascript-lint
 #      - javascript-tests:
 #          requires:
 #            - javascript-lint

--- a/.karma.conf.js
+++ b/.karma.conf.js
@@ -116,7 +116,6 @@ module.exports = function(config) {
             'karma-qunit',
             'karma-coverage'
         ],
-        basePath: '',
         autoWatch: true,
         concurrency: 1,
         frameworks: ['qunit'],

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -385,6 +385,7 @@
             - The HTML id "editforms" has been removed.
             - The CSS class "table_detail_view" is not use anymore.
             - the CSS files "creme_core/css/blocks.css" have been removed from in the setting "CREME_CORE_CSS" (they will be removed in Creme 2.4)
+        # The Makefile target 'karma-ci' is no longer used in circleci script and removed.
         # Apps :
             * Creme_config :
                 - There are several changes about Custom-Forms :

--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,11 @@ karma-browsers: media karma-clean
 
 	@echo "file://$(shell pwd)/artifacts/karma_coverage/html/index.html"
 
-## TODO: remove ("circleci is hard-coded => move to cicleCI configuration")
+
 ## Run the Javascript test suite in CI (generatemedia is supposed to be already done)
-.PHONY: karma-ci
-karma-ci:
-	node_modules/.bin/karma start .circleci/.karma.conf.js --targets=$(filter-out $@,$(MAKECMDGOALS))
+## .PHONY: karma-ci
+## karma-ci:
+##	node_modules/.bin/karma start .circleci/.karma.conf.js --targets=$(filter-out $@,$(MAKECMDGOALS))
 
 
 ## Run the application

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ update: update-requirements
 .PHONY: node-update
 node-update:
 	npm install --no-save
+	npm run eslint-install
 
 
 ## Generate the media files

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "creme-trunk",
     "version": "2.3.0",
     "license": "AGPL-3.0",
+    "scripts": {
+        "eslint-install": "npm i \"file:${ESLINT_CREME_PLUGINS:-creme/static/utils/eslint/}/eslint-plugin-template-0.5.0-hybird.tgz\" --no-save"
+    },
     "dependencies": {
         "ansi-regex": ">=5.0.1",
         "argparse": "1.0.9",
@@ -9,7 +12,6 @@
         "colors": "^1.4.0",
         "eslint": "7.32.0",
         "eslint-plugin-standard": "5.0.0",
-        "eslint-plugin-template": "file:creme/static/utils/eslint/eslint-plugin-template-0.5.0-hybird.tgz",
         "graceful-fs": "^4.1.15",
         "has-flag": "4.0.0",
         "istanbul": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "jquery": "3.6.0",
         "js-yaml": "3.13.1",
         "jsdom": "11.0.0",
+        "json-schema": ">=0.4.0",
         "karma": "6.0.4",
         "karma-chrome-launcher": "3.1.0",
         "karma-cli": "^2.0.0",


### PR DESCRIPTION
The new deployment mechanism on a separate directory needs some changes in the CI :

- Improving karma tools.
	  `--djangoStatics` : path to the compiled or packaged statics files served by django (default: `creme/media/statics`)
	  `--djangoSources` : root path to the tests files sources (default: `creme`)
	  `--coverageOutput` : directory of karma coverage output (default: `artifacts/karma_coverage`)
	  **Note**: Those arguments can be defines with the following environment variables:
	  `KARMA_DJANGOSTATICS`,  `KARMA_DJANGOSOURCES` & `KARMA_COVERAGEOUTPUT`
- Refactor circleci steps