### PR TITLE
serialize FieldsConfig with primary natural_key

### DIFF
--- a/creme/creme_core/models/fields.py
+++ b/creme/creme_core/models/fields.py
@@ -224,6 +224,8 @@ class CTypeOneToOneField(CTypeDescriptorMixin, models.OneToOneField):
         # In a normal use, ContentType instances are never deleted ;
         # so CASCADE by default should be OK
         kwargs.setdefault('on_delete', CASCADE)
+        if kwargs.get('primary_key'):
+            kwargs['parent_link'] = True
 
         super().__init__(**kwargs)
 

--- a/creme/creme_core/models/fields_config.py
+++ b/creme/creme_core/models/fields_config.py
@@ -119,6 +119,10 @@ class FieldsConfigManager(models.Manager):
     #         model, depth=0, only_leaves=False,
     #     ).filter(viewable=True, optional=True)
 
+    def get_by_natural_key(self, app_label, model):
+        ct = ContentType.objects.get_by_natural_key(app_label, model)
+        return self.get_for_model(ct.model_class())
+
     def get_for_model(self, model: Type['Model']) -> 'FieldsConfig':
         return self.get_for_models((model,))[model]
 
@@ -572,3 +576,6 @@ class FieldsConfig(CremeModel):
                         .get_field(field_name)
                         .formfield(required=True)
                 )
+
+    def natural_key(self):
+        return self.content_type.natural_key()


### PR DESCRIPTION
To allow the use of django's `dumpdata` and `loaddata` commands