### PR TITLE
CircleCI: Legacy Convenience Image Deprecation trunk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - << parameters.python >>-creme_crm-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
-            - << parameters.python >>-creme_crm
+            - << parameters.python >>-creme_crm-CIV2-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
+            - << parameters.python >>-creme_crm-CIV2
 
       - run: <<parameters.python>> -m venv ~/venv
       # Require setuptools v46.4.0 at least
@@ -49,7 +49,7 @@ commands:
       - run: pip list --outdated
 
       - save_cache:
-          key: << parameters.python >>-creme_crm-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
+          key: << parameters.python >>-creme_crm-CIV2-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
           paths: "~/venv"
 
   install-node-env:
@@ -133,54 +133,36 @@ commands:
             echo "export LANGUAGE=<< parameters.language >>" >> $BASH_ENV
             echo "export LC_ALL=<< parameters.language >>.<< parameters.encoding >>" >> $BASH_ENV
 
+orbs:
+  browser-tools: circleci/browser-tools@1.2.5
 
 jobs:
-#  python36-lint-isort:
   python37-lint-isort:
     docker:
-#      - image: circleci/python:3.6
-      - image: circleci/python:3.7
-    steps:
-      - checkout-creme
-      - install-py-dev-env:
-#          python: "python3.6"
-          python: "python3.7"
-      - run: make -C << pipeline.parameters.source_path >> isort-check
-
-
-#  python36-lint-flake8:
-  python37-lint-flake8:
-    docker:
-#      - image: circleci/python:3.6
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout-creme
       - install-creme-system-packages
       - install-py-dev-env:
-#          python: "python3.6"
+          python: "python3.7"
+      - run: make -C << pipeline.parameters.source_path >> isort-check
+
+
+  python37-lint-flake8:
+    docker:
+      - image: cimg/python:3.7
+    steps:
+      - checkout-creme
+      - install-creme-system-packages
+      - install-py-dev-env:
           python: "python3.7"
       - run: flake8 << pipeline.parameters.source_path >>/creme/ --config << pipeline.parameters.source_path >>/setup.cfg
 
 
-#  python37-creme-checks:
-#    docker:
-#      - image: circleci/python:3.7
-#    steps:
-#      - checkout-creme
-#      - install-creme-system-packages
-#      - run: sudo apt install enchant-2 hunspell hunspell-fr -y
-#      - install-py-dev-env:
-#          python: "python3.7"
-#      - create-creme-project
-#      - run: creme i18n_spellcheck --allow-failure --settings=<< pipeline.parameters.instance_directory >>.settings
-
-
-#  python36-tests-mysql:
   python37-tests-mysql:
     docker:
-#      - image: circleci/python:3.6-browsers
-      - image: circleci/python:3.7-browsers
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/python:3.7
+      - image: cimg/mysql:5.7
         environment:
           MYSQL_ROOT_PASSWORD: creme
           MYSQL_DATABASE: cremecrm
@@ -195,7 +177,6 @@ jobs:
       - install-creme-system-packages
       - run: sudo apt install -y mariadb-client
       - install-py-dev-env:
-#          python: "python3.6"
           python: "python3.7"
       - create-creme-project
       - setup-creme-unit-tests:
@@ -203,12 +184,10 @@ jobs:
       - run-creme-unit-tests
 
 
-#  python36-tests-pgsql:
   python37-tests-pgsql:
     docker:
-#      - image: circleci/python:3.6-browsers
-      - image: circleci/python:3.7-browsers
-      - image: circleci/postgres:12-ram
+      - image: cimg/python:3.7
+      - image: cimg/postgres:12.10
         environment:
           POSTGRES_USER: creme
           POSTGRES_PASSWORD: creme
@@ -223,7 +202,6 @@ jobs:
           port: 5432
       - install-creme-system-packages
       - install-py-dev-env:
-#          python: "python3.6"
           python: "python3.7"
       - create-creme-project
       - setup-creme-unit-tests:
@@ -231,26 +209,9 @@ jobs:
       - run-creme-unit-tests
 
 
-#  python36-tests-sqlite3:
-#    docker:
-#      - image: circleci/python:3.6-browsers
-#    resource_class: large
-#    steps:
-#      - checkout-creme
-#      - setup-locale:
-#          language: fr_FR
-#          encoding: UTF-8
-#      - install-creme-system-packages
-#      - install-py-dev-env:
-#          python: "python3.6"
-#      - create-creme-project
-#      - setup-creme-unit-tests
-#      - run-creme-unit-tests
-
-
   python37-tests-sqlite3:
     docker:
-      - image: circleci/python:3.7-browsers
+      - image: cimg/python:3.7
     resource_class: large
     steps:
       - checkout-creme
@@ -267,7 +228,7 @@ jobs:
 
   python38-tests-sqlite3:
     docker:
-      - image: circleci/python:3.8-browsers
+      - image: cimg/python:3.8
     resource_class: large
     steps:
       - checkout-creme
@@ -284,7 +245,7 @@ jobs:
 
   python39-tests-sqlite3:
     docker:
-      - image: circleci/python:3.9-browsers
+      - image: cimg/python:3.9
     resource_class: large
     steps:
       - checkout-creme
@@ -300,7 +261,7 @@ jobs:
 
   python310-tests-sqlite3:
     docker:
-      - image: circleci/python:3.10-browsers
+      - image: cimg/python:3.10
     resource_class: large
     steps:
       - checkout-creme
@@ -316,12 +277,11 @@ jobs:
 
   javascript-lint:
     docker:
-#     - image: circleci/python:3.6-node-browsers
-     - image: circleci/python:3.7-node-browsers
+     - image: cimg/python:3.7-node
     steps:
       - checkout-creme
+      - install-creme-system-packages
       - install-py-dev-env:
-#          python: "python3.6"
           python: "python3.7"
       - create-creme-project
       - setup-creme-statics
@@ -353,9 +313,9 @@ jobs:
 
   javascript-tests:
     docker:
-#     - image: circleci/python:3.6-node-browsers
-     - image: circleci/python:3.7-node-browsers
+     - image: cimg/python:3.7-browsers
     steps:
+      - browser-tools/install-browser-tools
       - checkout-creme
       - install-creme-system-packages
       - install-py-dev-env:
@@ -416,8 +376,8 @@ jobs:
 
   creme-package:
     docker:
-#      - image: circleci/python:3.6-browsers
-      - image: circleci/python:3.7-browsers
+#      - image: cimg/python:3.7-browsers
+      - image: cimg/python:3.7
     steps:
       - checkout-creme
       - run: pip install -U pip setuptools twine wheel
@@ -446,61 +406,42 @@ workflows:
               only: /.*/
           requires:
             - javascript-lint
-#      - python37-creme-checks
-#      - python36-lint-isort:
       - python37-lint-isort:
           filters:
             tags:
               only: /.*/
-#      - python36-lint-flake8:
       - python37-lint-flake8:
           filters:
             tags:
               only: /.*/
-#      - python36-tests-sqlite3:
-#          filters:
-#            tags:
-#              only: /.*/
-#          requires:
-#            - python36-lint-isort
-#            - python36-lint-flake8
-#      - python36-tests-mysql:
       - python37-tests-mysql:
           filters:
             tags:
               only: /.*/
           requires:
-#            - python36-lint-isort
             - python37-lint-isort
-#            - python36-lint-flake8
             - python37-lint-flake8
-#      - python36-tests-pgsql:
       - python37-tests-pgsql:
           filters:
             tags:
               only: /.*/
           requires:
-#            - python36-lint-isort
             - python37-lint-isort
-#            - python36-lint-flake8
             - python37-lint-flake8
       - python37-tests-sqlite3:
+          filters:
+            tags:
+              only: /.*/
           requires:
-#            - python36-lint-isort
             - python37-lint-isort
-#            - python36-lint-flake8
             - python37-lint-flake8
       - python38-tests-sqlite3:
           requires:
-#            - python36-lint-isort
             - python37-lint-isort
-#            - python36-lint-flake8
             - python37-lint-flake8
       - python39-tests-sqlite3:
           requires:
-#            - python36-lint-isort
             - python37-lint-isort
-#            - python36-lint-flake8
             - python37-lint-flake8
       - python310-tests-sqlite3:
           requires:
@@ -519,11 +460,8 @@ workflows:
           requires:
             - docker-build-creme-demo
             - javascript-tests
-#            - python36-tests-sqlite3
             - python37-tests-sqlite3
-#            - python36-tests-mysql
             - python37-tests-mysql
-#            - python36-tests-pgsql
             - python37-tests-pgsql
       - creme-package:
           filters:
@@ -533,9 +471,6 @@ workflows:
               ignore: /.*/
           requires:
             - javascript-tests
-#            - python36-tests-sqlite3
             - python37-tests-sqlite3
-#            - python36-tests-mysql
             - python37-tests-mysql
-#            - python36-tests-pgsql
             - python37-tests-pgsql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,13 +107,16 @@ commands:
   run-creme-unit-tests:
     description: Run Creme unit tests
     steps:
-      # File .coveragerc is implicitly used by coverage.py (use argument "--rcfile" instead?)
-      - run: cp << pipeline.parameters.source_path >>/.circleci/circleci_coverage.ini .coveragerc
-      - run: COVERAGE_PROCESS_START=.coveragerc coverage run --source << pipeline.parameters.source_path >>/creme/ << pipeline.parameters.source_path >>/creme/manage.py test --settings=<< pipeline.parameters.instance_directory >>.settings --noinput --parallel=8 creme
-      - run: coverage combine
-      - run: coverage html
+      - run:
+          name: "Run tests with coverage"
+          command: |
+            COVERAGE_PROCESS_START=<< pipeline.parameters.source_path >>/.coveragerc;
+            coverage run --source << pipeline.parameters.source_path >>/creme/ --rcfile << pipeline.parameters.source_path >>/.coveragerc \
+            << pipeline.parameters.source_path >>/creme/manage.py test --settings=<< pipeline.parameters.instance_directory >>.settings --noinput --parallel=8 creme
+      - run: coverage combine --rcfile << pipeline.parameters.source_path >>/.coveragerc
+      - run: coverage html --rcfile << pipeline.parameters.source_path >>/.coveragerc
       - store_artifacts:
-          # NB: see .circleci/circleci_coverage.ini
+          # NB: see .coveragerc file
           path: artifacts/coverage_html
 
   setup-locale:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,22 +34,25 @@ commands:
       python:
         type: string
     steps:
+      - run: which <<parameters.python>>
+
       - restore_cache:
           keys:
-            - << parameters.python >>-creme_crm-CIV2-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
-            - << parameters.python >>-creme_crm-CIV2
+            - << parameters.python >>-creme_crm-v2.4-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
+            - << parameters.python >>-creme_crm-v2.4
 
       - run: <<parameters.python>> -m venv ~/venv
       # Require setuptools v46.4.0 at least
       - run: ~/venv/bin/pip install -U pip setuptools
       - run: echo "source ~/venv/bin/activate" >> $BASH_ENV
+      - run: which python
       - run: pip install -U -e << pipeline.parameters.source_path >>[dev,mysql,pgsql,graphs]
       - run: python --version
       - run: pip freeze
       - run: pip list --outdated
 
       - save_cache:
-          key: << parameters.python >>-creme_crm-CIV2-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
+          key: << parameters.python >>-creme_crm-v2.4-{{ checksum "<< pipeline.parameters.source_path >>/setup.cfg" }}
           paths: "~/venv"
 
   install-node-env:
@@ -319,7 +322,6 @@ jobs:
       - checkout-creme
       - install-creme-system-packages
       - install-py-dev-env:
-#          python: "python3.6"
           python: "python3.7"
       - create-creme-project
       - setup-creme-statics
@@ -376,7 +378,6 @@ jobs:
 
   creme-package:
     docker:
-#      - image: cimg/python:3.7-browsers
       - image: cimg/python:3.7
     steps:
       - checkout-creme

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,7 @@
 [run]
 branch = True
-# source = ~/creme_crm/creme/
-parallel = true
-concurrency=multiprocessing,threading
+parallel = True
+concurrency=multiprocessing
 data_file=artifacts/coverage
 
 [report]

--- a/creme/creme_core/global_info.py
+++ b/creme/creme_core/global_info.py
@@ -28,11 +28,7 @@
 
 from collections import defaultdict
 from functools import wraps
-# try:
-#     from threading import currentThread
-# except ImportError:
-#     from dummy_threading import currentThread  # type: ignore
-from threading import currentThread
+from threading import current_thread
 from typing import DefaultDict, Hashable
 
 _globals: DefaultDict = defaultdict(dict)
@@ -45,7 +41,7 @@ def get_global_info(key: Hashable):
     @return The value corresponding to the key.
             <None> is returned if the key is not found.
     """
-    thread_globals = _globals.get(currentThread())
+    thread_globals = _globals.get(current_thread())
     return thread_globals and thread_globals.get(key)
 
 
@@ -54,12 +50,12 @@ def set_global_info(**kwargs) -> None:
 
     @param kwargs: Each key-value are sored as global data.
     """
-    _globals[currentThread()].update(kwargs)
+    _globals[current_thread()].update(kwargs)
 
 
 def clear_global_info() -> None:
-    # Don't use del _globals[currentThread()], it causes problems with dev server.
-    _globals.pop(currentThread(), None)
+    # Don't use del _globals[current_thread()], it causes problems with dev server.
+    _globals.pop(current_thread(), None)
 
 
 def get_per_request_cache() -> dict:

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
 
 [options.extras_require]
 dev=
-    coverage ~=6.1.2
+    coverage ~=6.3.2
     flake8 ~=4.0.1
     isort ~=5.10
     ipython
@@ -75,22 +75,6 @@ include_trailing_comma = True
 multi_line_output = 3
 use_parentheses = True
 skip_glob = */migrations/old/*
-
-[coverage:run]
-branch = True
-source = creme
-parallel = true
-concurrency=multiprocessing,threading
-data_file=artifacts/coverage
-
-[coverage:report]
-show_missing = True
-skip_covered = True
-omit = */migrations/*
-
-[coverage:html]
-directory=artifacts/coverage_html
-title = Coverage report
 
 [flake8]
 exclude =


### PR DESCRIPTION
Use the new cimg CircleCI images.
Invalidate the venv cache.
No more ram variants for the database images, fallback to the standard images.
Most jobs use standard python images; javascript tests require browsers support.
Fix tag builds: `python37-tests-sqlite3` runs with tags.