### PR TITLE
Do not copy the number when converting a 'billing' entity.

### DIFF
--- a/creme/billing/models/templatebase.py
+++ b/creme/billing/models/templatebase.py
@@ -2,7 +2,7 @@
 
 ################################################################################
 #    Creme is a free/open-source Customer Relationship Management software
-#    Copyright (C) 2009-2021  Hybird
+#    Copyright (C) 2009-2022  Hybird
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published by
@@ -76,7 +76,9 @@ class AbstractTemplateBase(Base):
 
         # Common rules for the recurrent generation of a "base" object for billing app.
         # See base's child for specific rules
-        instance.generate_number()
+        # instance.generate_number()
+        if not instance.generate_number_in_create:  # Avoid double generation
+            instance.generate_number()
         # TODO: user configurable rules ???
         instance.expiration_date = instance.issuing_date + timedelta(days=30)
 

--- a/creme/billing/tests/test_convert.py
+++ b/creme/billing/tests/test_convert.py
@@ -79,15 +79,16 @@ class ConvertTestCase(_BillingTestCase):
     @skipIfCustomQuote
     @skipIfCustomInvoice
     def test_convert01(self):
-        self.login()
+        user = self.login()
 
         currency = Currency.objects.create(
             name='Berry', local_symbol='B',
             international_symbol='BB', is_custom=True,
         )
 
-        create_orga = partial(Organisation.objects.create, user=self.user)
+        create_orga = partial(Organisation.objects.create, user=user)
         source = create_orga(name='Source Orga')
+        self._set_managed(source)
         target = create_orga(name='Target Orga')
 
         create_address = Address.objects.create
@@ -112,6 +113,8 @@ class ConvertTestCase(_BillingTestCase):
         address_count = Address.objects.count()
 
         quote = self.create_quote('My Quote', source, target, currency)
+        self.assertTrue(quote.number)
+
         quote.additional_info = AdditionalInformation.objects.all()[0]
         quote.payment_terms = PaymentTerms.objects.all()[0]
         quote.payment_info = PaymentInformation.objects.create(
@@ -141,6 +144,7 @@ class ConvertTestCase(_BillingTestCase):
             ),
             invoice.name,
         )
+        self.assertFalse(invoice.number)  # Not copied
 
         today = date.today()
         self.assertEqual(today, invoice.issuing_date)

--- a/creme/billing/tests/test_templatebase.py
+++ b/creme/billing/tests/test_templatebase.py
@@ -3,7 +3,7 @@
 from datetime import date, timedelta
 from functools import partial
 
-from django.conf import settings
+from django.test.utils import override_settings
 from django.utils.translation import gettext as _
 
 from creme.creme_core.core.function_field import function_field_registry
@@ -125,11 +125,10 @@ class TemplateBaseTestCase(_BillingTestCase):
         self.assertEqual(1, invoice.status_id)
 
     @skipIfCustomInvoice
+    @override_settings(INVOICE_NUMBER_PREFIX='INV')
     def test_create_invoice03(self):
         "Source is managed."
-        source = self.source
-        source.is_managed = True
-        source.save()
+        self._set_managed(self.source)
 
         invoice_status = self.get_object_or_fail(InvoiceStatus, pk=3)
 
@@ -140,7 +139,7 @@ class TemplateBaseTestCase(_BillingTestCase):
             invoice = tpl.create_entity()
 
         self.assertIsInstance(invoice, Invoice)
-        self.assertStartsWith(invoice.number, settings.INVOICE_NUMBER_PREFIX)
+        self.assertEqual('INV1', invoice.number)
 
     @skipIfCustomInvoice
     def test_create_invoice04(self):
@@ -182,6 +181,24 @@ class TemplateBaseTestCase(_BillingTestCase):
         self.assertIsNotNone(status)
         self.assertEqual(pk,    status.id)
         self.assertEqual(_('N/A'), status.name)
+
+    @skipIfCustomQuote
+    @override_settings(QUOTE_NUMBER_PREFIX='QU')
+    def test_create_quote03(self):
+        "Source is managed."
+        self._set_managed(self.source)
+
+        quote_status = self.get_object_or_fail(QuoteStatus, pk=2)
+        comment = '*Insert an nice comment here*'
+        tpl = self._create_templatebase(Quote, quote_status.id, comment)
+
+        with self.assertNoException():
+            quote = tpl.create_entity()
+
+        self.assertIsInstance(quote, Quote)
+        self.assertEqual(comment, quote.comment)
+        self.assertEqual(quote_status, quote.status)
+        self.assertEqual('QU1', quote.number)
 
     @skipIfCustomSalesOrder
     def test_create_order01(self):

--- a/creme/billing/views/convert.py
+++ b/creme/billing/views/convert.py
@@ -73,6 +73,12 @@ class Conversion(generic.base.EntityRelatedMixin, generic.CheckedView):
         src = self.get_related_entity()
         dest_class = self.get_destination_model(src)
 
+        # TODO: build() copy the number (it's a feature for recurrent generation
+        #       to fallback to the TemplateBase instance's number)
+        #       but here copy a Quote number into an Invoice number does not mean anything.
+        #  => add a argument 'copy_number=False'? do not use 'build()'?
+        src.number = ''
+
         with atomic():
             dest = dest_class()
             dest.build(src)


### PR DESCRIPTION
There was a double call to generate_number during recurrent generation.