### PR TITLE
CI: creme-package job; Upgrade pip before installing twine;

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,9 @@ jobs:
       - image: cimg/python:3.7
     steps:
       - checkout-creme
-      - run: pip install -U pip setuptools twine wheel
+      - run: pip install -U pip setuptools wheel
+      # We need an up-to-date pip version to install twine
+      - run: pip install -U twine
       # See environment variables:
       # - TWINE_REPOSITORY_URL
       # - TWINE_USERNAME


### PR DESCRIPTION
Twine relies on the cryptography package, which now depends on Rust to build.
To fetch a wheel and avoid building cryptography, we need an up-to-date version of pip.