### PR TITLE
Fix a few pager bugs

### DIFF
--- a/creme/creme_core/gui/pager.py
+++ b/creme/creme_core/gui/pager.py
@@ -78,10 +78,6 @@ class PagerLink:
 
 
 class PagerContext:
-    SHOW_ALL_PAGES_LIMIT: int = 5
-    SHOW_LAST_PAGE_LIMIT: int = 4
-    SHOW_FIRST_PAGE_LIMIT: int = 4
-
     count: int
     current: int
     previous: int | None
@@ -131,49 +127,48 @@ class PagerContext:
             ),
         ]
 
-        if page_count < self.SHOW_ALL_PAGES_LIMIT:
-            links.extend(
-                PagerLink(index, is_current=is_current(index))
-                for index in range(1, page_count + 1)
-            )
-        elif page_current <= self.SHOW_LAST_PAGE_LIMIT:
-            assert page_next is not None
+        first_page_help = None if page_count == 1 else _('To first page')
+        links.append(PagerLink(1, help=first_page_help, is_current=is_current(1)))
 
-            links.extend(
-                PagerLink(index, is_current=is_current(index))
-                for index in range(1, page_next + 1)
-            )
-            links.append(
-                PagerLink(page_next + 1, help=_('To another page'), group=PagerLink.CHOOSE)
-            )
-            links.append(PagerLink(page_count, help=_('To last page')))
-        elif page_current >= page_count - self.SHOW_FIRST_PAGE_LIMIT:
-            assert page_previous is not None
-
-            links.append(PagerLink(1, help=_('To first page')))
+        lo_overflow = page_current - 3
+        if lo_overflow == 1:
+            assert page_previous == 3
+            links.append(PagerLink(2))
+        elif lo_overflow >= 2:
+            assert page_previous >= 4
             links.append(
                 PagerLink(page_previous - 1, help=_('To another page'), group=PagerLink.CHOOSE)
             )
-            links.extend(
-                PagerLink(index, is_current=is_current(index))
-                for index in range(page_previous, page_count + 1)
-            )
-        else:
-            assert page_previous is not None
-            assert page_next is not None
 
-            links.append(PagerLink(1, help=_('To first page')))
+        if page_current >= 3:
             links.append(
-                PagerLink(page_previous - 1, help=_('To another page'), group=PagerLink.CHOOSE)
+                PagerLink(page_previous)
             )
-            links.extend(
-                PagerLink(index, is_current=is_current(index))
-                for index in range(page_previous, page_next + 1)
+
+        if page_current > 1 and page_current < page_count:
+            links.append(
+                PagerLink(page_current, is_current=True)
             )
+
+        if page_current <= page_count - 2:
+            links.append(
+                PagerLink(page_next)
+            )
+
+        hi_overflow = page_count - page_current - 2
+        if hi_overflow == 1:
+            assert page_next is not None
+            links.append(PagerLink(page_next + 1))
+        elif hi_overflow >= 2:
+            assert page_next is not None
             links.append(
                 PagerLink(page_next + 1, help=_('To another page'), group=PagerLink.CHOOSE)
             )
-            links.append(PagerLink(page_count, help=_('To last page')))
+
+        if page_count > 1:
+            links.append(
+                PagerLink(page_count, help=_('To last page'), is_current=is_current(page_count))
+            )
 
         links.append(
             PagerLink(

--- a/creme/creme_core/tests/gui/test_pager.py
+++ b/creme/creme_core/tests/gui/test_pager.py
@@ -219,3 +219,60 @@ class PagerContextTestCase(CremeTestCase):
             PagerLink(100, help=_('To last page')),
             PagerLink(51, label=_('Next page'), group='next')
         ], pager.links)
+
+    def test_middlepage_at_show_all_limit(self):
+        """Non-regression test for pager bug around the old size limits.
+        A single page in the high overflow shouldn't show the chooser: when there are 5 pages, on
+        page 3 there shouldn't be "4, ..., 5" in the pager.
+        """
+        page = Paginator([*range(5)], 1).page(3)
+        pager = PagerContext(page)
+
+        self.assertEqual(5, pager.count)
+
+        self.assertEqual(1, pager.first)
+        self.assertEqual(5, pager.last)
+
+        self.assertEqual(2, pager.previous)
+        self.assertEqual(3, pager.current)
+        self.assertEqual(4, pager.next)
+
+        # <previous|1|2|3|4|5|next>
+        self.assertPagerLinks([
+            PagerLink(2, label=_('Previous page'), group='previous'),
+            PagerLink(1, help=_('To first page')),
+            PagerLink(2, label='2'),
+            PagerLink(3, label='3', is_current=True),
+            PagerLink(4, label='4'),
+            PagerLink(5, label='5', help=_('To last page')),
+            PagerLink(4, label=_('Next page'), group='next')
+        ], pager.links)
+
+    def test_penultimate_page_at_show_all_limit(self):
+        """Non-regression test for pager bug around the old size limits.
+        In this situation, in addition to showing the chooser like in
+        `test_middlepage_at_show_all_limit`, the next and last pages are also duplicated: when
+        there are 5 pages, on page 4 there shouldn't be "4, 5, ..., 5" in the pager.
+        """
+        page = Paginator([*range(5)], 1).page(4)
+        pager = PagerContext(page)
+
+        self.assertEqual(5, pager.count)
+
+        self.assertEqual(1, pager.first)
+        self.assertEqual(5, pager.last)
+
+        self.assertEqual(3, pager.previous)
+        self.assertEqual(4, pager.current)
+        self.assertEqual(5, pager.next)
+
+        # <previous|1|2|3|4|5|next>
+        self.assertPagerLinks([
+            PagerLink(3, label=_('Previous page'), group='previous'),
+            PagerLink(1, help=_('To first page')),
+            PagerLink(2, label='2'),
+            PagerLink(3, label='3'),
+            PagerLink(4, label='4', is_current=True),
+            PagerLink(5, label='5', help=_('To last page')),
+            PagerLink(5, label=_('Next page'), group='next')
+        ], pager.links)

--- a/creme/creme_core/tests/gui/test_pager.py
+++ b/creme/creme_core/tests/gui/test_pager.py
@@ -68,9 +68,9 @@ class PagerContextTestCase(CremeTestCase):
         # <previous|1|2|3|next>
         self.assertPagerLinks([
             PagerLink(None, label=_('Previous page'), group='previous', enabled=False),
-            PagerLink(1, label='1', is_current=True),
+            PagerLink(1, label='1', is_current=True, help=_('To first page')),
             PagerLink(2, label='2'),
-            PagerLink(3, label='3'),
+            PagerLink(3, label='3', help=_('To last page')),
             PagerLink(2, label=_('Next page'), group='next')
         ], pager.links)
 
@@ -90,9 +90,9 @@ class PagerContextTestCase(CremeTestCase):
         # <previous|1|2|3|next>
         self.assertPagerLinks([
             PagerLink(1, label=_('Previous page'), group='previous'),
-            PagerLink(1, label='1'),
+            PagerLink(1, label='1', help=_('To first page')),
             PagerLink(2, label='2', is_current=True),
-            PagerLink(3, label='3'),
+            PagerLink(3, label='3', help=_('To last page')),
             PagerLink(3, label=_('Next page'), group='next')
         ], pager.links)
 
@@ -112,9 +112,9 @@ class PagerContextTestCase(CremeTestCase):
         # <previous|1|2|3|next>
         self.assertPagerLinks([
             PagerLink(2, label=_('Previous page'), group='previous'),
-            PagerLink(1, label='1'),
+            PagerLink(1, label='1', help=_('To first page')),
             PagerLink(2, label='2'),
-            PagerLink(3, label='3', is_current=True),
+            PagerLink(3, label='3', is_current=True, help=_('To last page')),
             PagerLink(None, label=_('Next page'), group='next', enabled=False)
         ], pager.links)
 
@@ -134,7 +134,7 @@ class PagerContextTestCase(CremeTestCase):
         # <previous|1|2|3|4|...|10|next>
         self.assertPagerLinks([
             PagerLink(2, label=_('Previous page'), group='previous'),
-            PagerLink(1, label='1'),
+            PagerLink(1, label='1', help=_('To first page')),
             PagerLink(2, label='2'),
             PagerLink(3, label='3', is_current=True),
             PagerLink(4, label='4'),
@@ -164,7 +164,7 @@ class PagerContextTestCase(CremeTestCase):
             PagerLink(7, label='7'),
             PagerLink(8, label='8', is_current=True),
             PagerLink(9, label='9'),
-            PagerLink(10, label='10'),
+            PagerLink(10, label='10', help=_('To last page')),
             PagerLink(9, label=_('Next page'), group='next')
         ], pager.links)
 


### PR DESCRIPTION
Cette PR corrige les quelques bugs que j'ai vu sur le pager ([là](https://demos.cremecrm.com/persons/organisation/4), [là](https://demos.cremecrm.com/persons/contact/13), et [là](https://demos.cremecrm.com/activities/activities?filter=&hfilter=activities-hf_activity&sort_key=regular_field-start&sort_order=DESC&selected_rows=&selection=multiple&q_filter=%7B%22op%22%3A%22AND%22%2C%22val%22%3A%5B%5D%7D&ct_id=77&search-regular_field-start-start=&search-regular_field-start-end=&search-regular_field-title=&search-relation-activities-object_participates_to_activity=&search-relation-activities-object_activity_subject=&search-regular_field-user=&search-regular_field-end-start=&search-regular_field-end-end=&search-regular_field-type=&search-regular_field-sub_type=&rows=10&page=4)):
- présence d'un page chooser mais il y a zéro ou une seule page à choisir
- liens next/last en doublon
- le help text sur first/last pas toujours présent

![image](https://user-images.githubusercontent.com/247183/197500205-0592f419-753c-42b8-a280-718d10fa2a11.png)
![image](https://user-images.githubusercontent.com/247183/197500281-d10c02c5-0033-4c80-aa1a-3771c766c9b5.png)
![image](https://user-images.githubusercontent.com/247183/197500213-2479ae28-2938-4835-957c-9e989a1d48a0.png)


Il devait manquer au moins 1 cas parmi les 3 familles de taille/position qui sont gérées actuellement, mais ajouter ces cas aux limites serait plus long que de calculer les simples règles pour chacun des 7 composants du pager (et serait en fait même un peu plus court que le code actuel).

J'ai donc enlevé les limites qui créent ces problèmes (et ajouté beaucoup de commentaires pour expliquer chaque étape) car pour moi elles découlent des règles d'affichage et pas l'inverse: pour cette forme

```python
#    first ... previous current next ... last
#          ^^^                       ^^^
#          low overflow area         high overflow area
```

on veut:
- pas de doublons dans first/prev/next/last (alors que first et last sont dans la pratique visibles quelque soit le nombre de pages, ce qui peut causer confusion avec les `SHOW_LAST_PAGE_LIMIT` et `SHOW_FIRST_PAGE_LIMIT` actuelles)
- un lien vers une page quand un des deux overflow n'est que de taille 1
- un chooser quand un overflow est de taille >=2

C'est plus facile de gérer chaque composant individuellement pour tout couvrir, que de les grouper dans des familles disjointes qui impactent tous les composants de façon différente. (Au "mieux" on peut utiliser une symétrie autour de la page courante et unifier `first/lo_overflow/prev` avec `next/hi_overflow/last` -- mais je pense que ça rendrait moins clair que ces 5-6 tests simples qui marchent tout le temps). A voir si ça vous plait.

J'ouvre la PR en draft pour que la CI check quand même si le fond et le forme de la PR sont corrects. Dans mes tests pager/listview/etc _ça avait l'air correct_.



