### PR TITLE
Improve geolocation map markers' labels

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -80,7 +80,7 @@
             - A new 'Relationship graph' brick is available, displaying the graph in the detail-view without having to download an image.
               Notice it can be downloaded as image too.
         * Mobile :
-            - A "owner" field is now present in forms for of Contacts & Organisations.
+            - An "owner" field is now present in forms to create Contacts & Organisations.
         * Polls :
             - The design of the 'Statistic' brick has changed.
         * Crudity :

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -85,6 +85,9 @@
             - The design of the 'Statistic' brick has changed.
         * Crudity :
             - The support of InfoPath files has been removed.
+        * Geolocation :
+            - Map markers now display more information when hovered: the actual address information. The title's importance has also been reduced, 
+              as it's usually less useful on a map than the address itself.
 
   Developers side :
   -----------------

--- a/creme/geolocation/static/geolocation/js/geolocation.js
+++ b/creme/geolocation/static/geolocation/js/geolocation.js
@@ -1,6 +1,6 @@
 /*******************************************************************************
     Creme is a free/open-source Customer Relationship Management software
-    Copyright (C) 2014-2020  Hybird
+    Copyright (C) 2014-2023  Hybird
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by
@@ -131,9 +131,22 @@ creme.geolocation.Location = creme.component.Component.sub({
     },
 
     markerLabel: function() {
+        // An address is typically shown as
+        // - owner: the creme entity (e.g. its name) this address belongs to
+        // - content: the actual street/city/etc information
+        // - title: the localized label for billing/shipping addresses (most of the time),
+        //          or a user-defined title for additional addresses
+
+        var title = this.title();
+        if (Object.isNotEmpty(title)) {
+            // If there's a title, it's usually less important than the actual address information,
+            // so we show it in parentheses.
+            title = "(" + title + ")";
+        }
         return [
             this.owner() || '',
-            this.title() || this.content()
+            this.content(),
+            title
         ].filter(Object.isNotEmpty).join('\n');
     }
 });

--- a/creme/geolocation/static/geolocation/js/tests/addresses-brick.js
+++ b/creme/geolocation/static/geolocation/js/tests/addresses-brick.js
@@ -438,7 +438,7 @@ QUnit.parametrize('creme.geolocation.brick.AddressesBrick (update filter)', [
                 this.assertMarkerProperties(mapController.getMarkerProperties('Address_C'), {
                     position: {lat: 42, lng: 5},
                     id: 'Address_C',
-                    title: 'Address C',
+                    title: '13013 Marseille\n(Address C)',
                     visible: true,
                     extraData: {}
                 });

--- a/creme/geolocation/static/geolocation/js/tests/geolocation-google.js
+++ b/creme/geolocation/static/geolocation/js/tests/geolocation-google.js
@@ -315,7 +315,7 @@ QUnit.test('creme.geolocation.GoogleMapController.markLocation (add marker)', fu
                 equal(false, Object.isNone(marker), 'marker exists');
                 equal(true, marker.getVisible(), 'marker is visible');
 
-                equal('fulbert\nAddress A', marker.getTitle());
+                equal('fulbert\n319 Rue Saint-Pierre, 13005 Marseille\n(Address A)', marker.getTitle());
                 deepEqual(new google.maps.LatLng({lat: 43.291628, lng: 5.4030217}), marker.getPosition());
                 deepEqual({
                     id: 'Address_A',
@@ -327,7 +327,7 @@ QUnit.test('creme.geolocation.GoogleMapController.markLocation (add marker)', fu
                 deepEqual([
                     ['marker-move', marker, {
                         id: 'Address_A',
-                        title: 'fulbert\nAddress A',
+                        title: 'fulbert\n319 Rue Saint-Pierre, 13005 Marseille\n(Address A)',
                         position: {
                             lat: 43.291628,
                             lng: 5.4030217

--- a/creme/geolocation/static/geolocation/js/tests/geolocation.js
+++ b/creme/geolocation/static/geolocation/js/tests/geolocation.js
@@ -58,7 +58,7 @@ QUnit.test('creme.geolocation.Location (getters)', function() {
 
     equal(gettext("Partially matching location"), location.statusLabel());
     equal('43.455810, 5.544000', location.positionLabel());
-    equal('joe\nAddress A', location.markerLabel());
+    equal('joe\n319 Rue Saint-Pierre, 13005 Marseille\n(Address A)', location.markerLabel());
 });
 
 QUnit.test('creme.geolocation.Location (copy)', function() {

--- a/creme/geolocation/static/geolocation/js/tests/persons-brick.js
+++ b/creme/geolocation/static/geolocation/js/tests/persons-brick.js
@@ -369,21 +369,21 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (markers)', [
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_A'), {
                 position: {lat: 43.291628, lng: 5.403022},
                 id: 'Address_A',
-                title: 'Address A',
+                title: '319 Rue Saint-Pierre, 13005 Marseille\n(Address A)',
                 visible: true,
                 extraData: {}
             });
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_B'), {
                 position: {lat: 43, lng: 5.5},
                 id: 'Address_B',
-                title: 'Address B',
+                title: 'Place inconnue, 13005 Marseille\n(Address B)',
                 visible: true,
                 extraData: {}
             });
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_C'), {
                 position: {lat: 42, lng: 5},
                 id: 'Address_C',
-                title: 'Address C',
+                title: '13013 Marseille\n(Address C)',
                 visible: true,
                 extraData: {}
             });
@@ -429,7 +429,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (toggle mark)', [
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_A'), {
                 position: {lat: 43.291628, lng: 5.403022},
                 id: 'Address_A',
-                title: 'Address A',
+                title: '319 Rue Saint-Pierre, 13005 Marseille\n(Address A)',
                 visible: true,
                 extraData: {}
             });
@@ -447,7 +447,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (toggle mark)', [
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_A'), {
                 position: {lat: 43.291628, lng: 5.403022},
                 id: 'Address_A',
-                title: 'Address A',
+                title: '319 Rue Saint-Pierre, 13005 Marseille\n(Address A)',
                 visible: false,
                 extraData: {}
             });
@@ -465,7 +465,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (toggle mark)', [
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_A'), {
                 position: {lat: 43.291628, lng: 5.403022},
                 id: 'Address_A',
-                title: 'Address A',
+                title: '319 Rue Saint-Pierre, 13005 Marseille\n(Address A)',
                 visible: true,
                 extraData: {}
             });
@@ -530,7 +530,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (add mark)', [
                 this.assertMarkerProperties(mapController.getMarkerProperties('Address_D'), {
                     position: {lat: 42, lng: 12},
                     id: 'Address_D',
-                    title: 'Address D',
+                    title: 'marseille\n(Address D)',
                     visible: true,
                     extraData: {}
                 });
@@ -557,7 +557,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (add mark)', [
                 this.assertMarkerProperties(mapController.getMarkerProperties('Address_D'), {
                     position: {lat: 42, lng: 12},
                     id: 'Address_D',
-                    title: 'Address D',
+                    title: 'marseille\n(Address D)',
                     visible: false,
                     extraData: {}
                 });
@@ -619,7 +619,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (move mark, save)', [
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_A'), {
                 position: {lat: 42, lng: 5.5},
                 id: 'Address_A',
-                title: 'Address A',
+                title: '319 Rue Saint-Pierre, 13005 Marseille\n(Address A)',
                 visible: true,
                 extraData: {}
             });
@@ -671,7 +671,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (move mark, save failed)
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_A'), {
                 position: {lat: 43.291628, lng: 5.403022},
                 id: 'Address_A',
-                title: 'Address A',
+                title: '319 Rue Saint-Pierre, 13005 Marseille\n(Address A)',
                 visible: true,
                 extraData: {}
             });
@@ -714,7 +714,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (move mark, no url)', [
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_A'), {
                 position: {lat: 43.291628, lng: 5.403022},
                 id: 'Address_A',
-                title: 'Address A',
+                title: '319 Rue Saint-Pierre, 13005 Marseille\n(Address A)',
                 visible: true,
                 extraData: {}
             });
@@ -756,7 +756,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (reset, no geolocation)'
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_C'), {
                 position: {lat: 42, lng: 5},
                 id: 'Address_C',
-                title: 'Address C',
+                title: '13013 Marseille\n(Address C)',
                 visible: true,
                 extraData: {}
             });
@@ -782,7 +782,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (reset, no geolocation)'
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_C'), {
                 position: {lat: 42, lng: 5},
                 id: 'Address_C',
-                title: 'Address C',
+                title: '13013 Marseille\n(Address C)',
                 visible: true,
                 extraData: {}
             });
@@ -826,7 +826,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (reset, not found)', [
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_B'), {
                 position: {lat: 43, lng: 5.5},
                 id: 'Address_B',
-                title: 'Address B',
+                title: 'Place inconnue, 13005 Marseille\n(Address B)',
                 visible: true,
                 extraData: {}
             });
@@ -840,7 +840,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (reset, not found)', [
                 this.assertMarkerProperties(mapController.getMarkerProperties('Address_B'), {
                     position: {lat: 43, lng: 5.5},
                     id: 'Address_B',
-                    title: 'Address B',
+                    title: 'Place inconnue, 13005 Marseille\n(Address B)',
                     visible: true,
                     extraData: {}
                 });
@@ -901,7 +901,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (reset, not visible)', [
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_B'), {
                 position: {lat: 43, lng: 5.5},
                 id: 'Address_B',
-                title: 'Address B',
+                title: 'Place inconnue, 13005 Marseille\n(Address B)',
                 visible: false,
                 extraData: {}
             });
@@ -924,7 +924,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (reset, not visible)', [
                 this.assertMarkerProperties(mapController.getMarkerProperties('Address_B'), {
                     position: {lat: 43, lng: 5.5},
                     id: 'Address_B',
-                    title: 'Address B',
+                    title: 'Place inconnue, 13005 Marseille\n(Address B)',
                     visible: false,
                     extraData: {}
                 });
@@ -977,7 +977,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (reset, improve accuracy
             this.assertMarkerProperties(mapController.getMarkerProperties('Address_C'), {
                 position: {lat: 42, lng: 5},
                 id: 'Address_C',
-                title: 'Address C',
+                title: '13013 Marseille\n(Address C)',
                 visible: true,
                 extraData: {}
             });
@@ -1001,7 +1001,7 @@ QUnit.parametrize('creme.geolocation.brick.PersonsBrick (reset, improve accuracy
                 this.assertMarkerProperties(mapController.getMarkerProperties('Address_C'), {
                     position: {lat: 43.178801, lng: 4.5048807},
                     id: 'Address_C',
-                    title: 'Address C',
+                    title: '13013 Marseille\n(Address C)',
                     visible: true,
                     extraData: {}
                 });


### PR DESCRIPTION
It now includes the "content", the actual street/etc information, in addition to its owner and title.

Works similarly for Google Maps and OSM markers.

![image](https://user-images.githubusercontent.com/247183/210816696-62f8d62d-be8f-436f-84e2-b851cfe01d0b.png)

![image](https://user-images.githubusercontent.com/247183/210816746-809f1191-9042-4f3c-9ff6-e7daed5f94db.png)
