### PR TITLE
fix icon parameter in widget_help_sign

### DIFF
--- a/creme/creme_core/templates/creme_core/templatetags/widgets/help-sign.html
+++ b/creme/creme_core/templates/creme_core/templatetags/widgets/help-sign.html
@@ -1,5 +1,5 @@
 {% load creme_widgets %}
 <div class="help-sign">
-    {% widget_icon name='info' size='help-sign' %}
+    {% widget_icon name=icon size='help-sign' %}
     <p>{{message|linebreaksbr}}</p>
 </div>

--- a/creme/creme_core/tests/templatetags/test_creme_widgets.py
+++ b/creme/creme_core/tests/templatetags/test_creme_widgets.py
@@ -539,3 +539,26 @@ class CremeWidgetsTagsTestCase(CremeTestCase):
             ),
             render,
         )
+
+    def test_widget_help_sign_with_another_icon(self):
+        theme = 'icecream'
+
+        with self.assertNoException():
+            render = Template(
+                r'{% load creme_widgets %}'
+                r'{% widget_help_sign message=help_msg icon="cancel" %}'
+            ).render(Context({
+                'THEME_NAME': theme,
+                'help_msg': 'Be careful:\ndo not duplicate entities!',
+            }))
+
+        self.assertHTMLEqual(
+            '<div class="help-sign">'
+            '<img src="{}" title="" alt="" width="16px"><p>'
+            'Be careful:<br>do not duplicate entities!'
+            '</p>'
+            '</div>'.format(
+                get_creme_media_url(theme, 'images/cancel_16.png'),
+            ),
+            render,
+        )


### PR DESCRIPTION
Hello,

little issue: The `icon` parameter in the templatetags [widget_help_sign](https://github.com/HybirdCorp/creme_crm/blob/main/creme/creme_core/templatetags/creme_widgets.py#L364) is not taking in account in the template of the widget and it's always the `info` icon instead.

I am not sure if I have to make an entry in the changelogs file for a so little change :) ?

Thanks !