### PR TITLE
Since the relation 'subject of activity' is internal we need to remove them before deleting an Activity (backport 2.5.3)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,8 @@
         # Apps :
             * Activities :
                 - Fix an issue in the deepcopy of the property 'limit_choices_to' of ActivitySubTypeField : it was lost and the choices not filtered.
+                - Fix Activity deletion : Since the relation 'subject of activity' is internal we need to remove them before deleting.
+
 
 == Version 2.5.2 ==
 

--- a/creme/activities/models/activity.py
+++ b/creme/activities/models/activity.py
@@ -201,7 +201,11 @@ class AbstractActivity(CremeEntity):
         )
 
     def _pre_delete(self):
-        for relation in self.relations.filter(type=REL_OBJ_PART_2_ACTIVITY):
+        relations = self.relations.filter(
+            type__in=(REL_OBJ_PART_2_ACTIVITY, REL_OBJ_ACTIVITY_SUBJECT)
+        )
+
+        for relation in relations:
             relation._delete_without_transaction()
 
 

--- a/creme/activities/tests/test_activity.py
+++ b/creme/activities/tests/test_activity.py
@@ -1847,7 +1847,7 @@ class ActivityTestCase(_ActivitiesTestCase):
 
     @skipIfCustomContact
     @override_settings(ENTITIES_DELETION_ALLOWED=True)
-    def test_delete02(self):
+    def test_delete__rel_part_2_activity(self):
         "Relations constants.REL_SUB_PART_2_ACTIVITY are removed when the Activity is deleted."
         # user = self.login()
         user = self.login_as_root_and_get()
@@ -1859,6 +1859,27 @@ class ActivityTestCase(_ActivitiesTestCase):
         rel = Relation.objects.create(
             user=user, subject_entity=musashi,
             type_id=constants.REL_SUB_PART_2_ACTIVITY,
+            object_entity=activity,
+        )
+
+        self.assertPOST200(activity.get_delete_absolute_url(), follow=True)
+        self.assertDoesNotExist(activity)
+        self.assertDoesNotExist(rel)
+        self.assertStillExists(musashi)
+
+    @skipIfCustomContact
+    @override_settings(ENTITIES_DELETION_ALLOWED=True)
+    def test_delete__rel_activity_subject(self):
+        "Relations constants.REL_SUB_ACTIVITY_SUBJECT are removed when the Activity is deleted."
+        user = self.login_as_root_and_get()
+
+        activity = self._create_meeting(user=user)
+        activity.trash()
+
+        musashi = Contact.objects.create(user=user, first_name='Musashi', last_name='Miyamoto')
+        rel = Relation.objects.create(
+            user=user, subject_entity=musashi,
+            type_id=constants.REL_SUB_ACTIVITY_SUBJECT,
             object_entity=activity,
         )
 


### PR DESCRIPTION
…