### PR TITLE
Refactor ForeignKey check on HistoryLine

### DIFF
--- a/creme/creme_config/tests/test_generics_views.py
+++ b/creme/creme_config/tests/test_generics_views.py
@@ -792,7 +792,7 @@ class GenericModelConfigTestCase(CremeTestCase, BrickTestCaseMixin):
         self.assertIsNotNone(hline)
         self.assertEqual(TYPE_EDITION, hline.type)
         self.assertListEqual(
-            [['status', status2del.id, default_status.id]],
+            [['status_id', status2del.id, default_status.id]],
             hline.modifications,
         )
 
@@ -881,7 +881,7 @@ class GenericModelConfigTestCase(CremeTestCase, BrickTestCaseMixin):
         self.assertIsNotNone(hline)
         self.assertEqual(TYPE_EDITION, hline.type)
         self.assertListEqual(
-            [['priority', prio2del.id, fallback_priority.id]],
+            [['priority_id', prio2del.id, fallback_priority.id]],
             hline.modifications,
         )
 

--- a/creme/creme_core/models/history.py
+++ b/creme/creme_core/models/history.py
@@ -179,7 +179,10 @@ class _HistoryLineType:
             )
 
             for field in instance._meta.fields:
-                fname = field.name
+                # use get_attname instead of name to check ids for foreignkeys
+                # instead of the entity to optimize queries' number
+                # fname = field.name
+                fname = field.get_attname()
 
                 if fname in excluded_fields or not field.get_tag(FieldTag.VIEWABLE):
                     continue
@@ -187,10 +190,11 @@ class _HistoryLineType:
                 old_value = getattr(old_instance, fname)
                 new_value = getattr(instance, fname)
 
-                if isinstance(field, ForeignKey):
-                    old_value = old_value and old_value.pk
-                    new_value = new_value and new_value.pk
-                else:
+                # if isinstance(field, ForeignKey):
+                #     old_value = old_value and old_value.pk
+                #     new_value = new_value and new_value.pk
+                # else:
+                if not isinstance(field, ForeignKey):
                     try:
                         # Sometimes a form sets a string representing an int in
                         # an IntegerField (for example)

--- a/creme/creme_core/tests/models/test_history.py
+++ b/creme/creme_core/tests/models/test_history.py
@@ -261,10 +261,10 @@ about this fantastic animation studio."""
         self.assertIn(['phone', old_phone, phone], modifs)
         self.assertIn(['email', email], modifs)
         self.assertIn(['description', old_description, description], modifs)
-        self.assertIn(['sector', sector01.id, sector02.id], modifs)
+        self.assertIn(['sector_id', sector01.id, sector02.id], modifs)
         self.assertIn(['creation_date', '1984-12-24'], modifs)
         self.assertIn(['subject_to_vat', True], modifs, modifs)
-        self.assertIn(['legal_form', lform.id, None], modifs, modifs)
+        self.assertIn(['legal_form_id', lform.id, None], modifs, modifs)
 
     def test_edition_no_change(self):
         "No change."
@@ -335,7 +335,15 @@ about this fantastic animation studio."""
         img = FakeImage.objects.create(user=user, name='Grumpy Hayao')
 
         hayao.image = img
-        with self.assertNumQueries(7):
+
+        # Queries:
+        #   - UPDATE CremeEntity
+        #   - UPDATE FakeContact
+        #   - SELECT CremeUser (with id)
+        #   - INSERT HistoryLine
+        #   - SELECT HistoryConfigItem
+        #   - SELECT Alert (needs Assistants app, for signals._update_alert_trigger_date())
+        with self.assertNumQueries(6):
             hayao.save()
 
         hline = HistoryLine.objects.order_by('-id')[0]

--- a/creme/creme_core/tests/models/test_history.py
+++ b/creme/creme_core/tests/models/test_history.py
@@ -335,7 +335,8 @@ about this fantastic animation studio."""
         img = FakeImage.objects.create(user=user, name='Grumpy Hayao')
 
         hayao.image = img
-        hayao.save()
+        with self.assertNumQueries(7):
+            hayao.save()
 
         hline = HistoryLine.objects.order_by('-id')[0]
         self.assertEqual(hayao.id,     hline.entity.id)


### PR DESCRIPTION
**Issue:**
Currently, Creme `HistoryLine` check if a `ForeignKey` field has changed by comparing entities, so there is a DB request to get the old entity.

**Proposition:**
To avoid this request for each `ForeignKey` field, we can just compare the ids.

**Side effect 1:**
After this change, in `HistoryLine.modifications` property, we have `name_id` instead of `name`. 
For exemple: `['sector_id', sector01.id, sector02.id]` instead of `['sector', sector01.id, sector02.id]`

I tested the two versions by modifing a profile img and the history lines are displayed correctly before and after the change.

![image](https://github.com/HybirdCorp/creme_crm/assets/3193898/d904619f-2aef-4fde-9f4b-2dd85b437e5c)
In the screen, the first modification hline is without the change and the second modification hline is with the change

I am not sure if it's a problem or not. 


**Side effect 2:**

The change of this PR made me notice and fix a "silent" error raise in the following test: `creme.sms.tests.test_sending.SendingsTestCase.test_create01`

During this test, there was an error because the campaign object doesn't exist yet during the creation of the sending modification history line. With the change, we have 2 history lines instead of 1:
one for the `sending` entity creation and another for the `sending` entity modification after its sending.

Here a link to the silent error raise in CI for creme 2.5 : https://app.circleci.com/pipelines/github/HybirdCorp/creme_crm/4208/workflows/647e97cc-b4fd-4451-8026-09688c93d9b4/jobs/30916/parallel-runs/0/steps/0-130?invite=true#step-130-659322_94

~there is another test that fail on mobile activities and I don't know why yet…~
creme.mobile.tests.test_activities.MobileActivitiesTestCase only in 3.8 sqlite (edit: the test passed when I re-run it the third time, strange…)
