### PR TITLE
Fix the creation of property types

### DIFF
--- a/creme/creme_config/forms/creme_property_type.py
+++ b/creme/creme_config/forms/creme_property_type.py
@@ -32,3 +32,7 @@ class CremePropertyForm(core_forms.CremeModelForm):
 
     class Meta(core_forms.CremeModelForm.Meta):
         model = CremePropertyType
+
+    def save(self, *args, **kwargs):
+        self.instance.is_custom = True
+        return super().save(*args, **kwargs)

--- a/creme/creme_config/tests/test_creme_property_type.py
+++ b/creme/creme_config/tests/test_creme_property_type.py
@@ -64,6 +64,7 @@ class PropertyTypeTestCase(BrickTestCaseMixin, CremeTestCase):
         self.assertEqual(count + 1, len(prop_types))
 
         prop_type = self._find_property_type(prop_types, text)
+        self.assertTrue(prop_type.is_custom)
         self.assertFalse(prop_type.subject_ctypes.all())
 
     def test_create02(self):
@@ -126,6 +127,7 @@ class PropertyTypeTestCase(BrickTestCaseMixin, CremeTestCase):
 
         pt = self.refresh(pt)
         self.assertEqual(text, pt.text)
+        self.assertTrue(pt.is_custom)
         self.assertListEqual([FakeOrganisation], [*pt.subject_models])
 
     def test_edit_error01(self):


### PR DESCRIPTION
Fix the creation of property types in creme_config: they were not marked as custom.