### PR TITLE
Replace pdflatex with LuaLatex and latexmk

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -82,6 +82,8 @@
                 - When a button is disabled, the reason is displayed as tool-tip.
                 - The constraints for properties & relationships are better respected.
             - In the list-views for Product/Service lines, lines related to deleted Invoice/Quote/... are excluded.
+            - Replaced PDFLaTeX with latexmk and LuaTeX as the LaTex compiler for billing templates. This change requires
+              the additional Ubuntu package 'latexmk' to be installed.
         * Opportunities :
             - You can now create unsuccessful phone calls from an Opportunity's detail-view :
                 - A button has been added (not enabled in default installations).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ virtual env, in order to keep the old one working).
        If you want PDF export, you can use :
        - xhtml2pdf (default)
        - weasyprint (easy to install on Linux ; harder on Windows)
-       - you can also use the binary "pdflatex" (Ubuntu package 'texlive-latex-base').
+       - you can also use the binary "latexmk" with "lualatex" (Ubuntu packages 'latexmk' and 'texlive-latex-base').
 
 Installation with 'pip':
  - You should probably use "virtualenv".

--- a/creme/billing/exporters/latex.py
+++ b/creme/billing/exporters/latex.py
@@ -1,6 +1,7 @@
 ################################################################################
 #    Creme is a free/open-source Customer Relationship Management software
 #    Copyright (C) 2009-2024  Hybird
+#    Copyright (C) 2025 Patrick Baus <patrick.baus@quantum-electronic-devices.de>
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published by
@@ -57,9 +58,10 @@ class LatexExporter(ContextMixin, base.BillingExporter):
         # NB: return code seems always 1 even when there is no error...
         subprocess.call(
             [
-                'pdflatex',
-                '-interaction=batchmode',
-                '-output-directory', dir_path,
+                'latexmk',
+                '-lualatex',
+                '-quiet',
+                '-cd',
                 latex_file_path,
             ]
         )

--- a/creme/billing/templates/billing/export/latex/FR/fr_FR/clear/base.tex
+++ b/creme/billing/templates/billing/export/latex/FR/fr_FR/clear/base.tex
@@ -7,8 +7,6 @@
 \documentclass[french,11pt]{article}
 \usepackage[french]{babel}
 \usepackage[french]{layout}
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
 \usepackage[a4paper]{geometry}
 \usepackage{units}
 \usepackage{bera}

--- a/creme/billing/tests/test_export.py
+++ b/creme/billing/tests/test_export.py
@@ -53,7 +53,7 @@ from .base import (
 )
 from .fake_exporters import OnlyInvoiceExportEngine
 
-pdflatex_not_installed = which('pdflatex') is None
+latex_not_installed = which('lualatex') is None or which('latexmk') is None
 
 try:
     import weasyprint  # NOQA
@@ -360,7 +360,7 @@ class ExportTestCase(BrickTestCaseMixin, _BillingTestCase):
         self.assertEqual('it_IT', flavour4.language)
         self.assertEqual('theme/with/odd/name', flavour4.theme)
 
-    @skipIf(pdflatex_not_installed, '"pdflatex" is not installed.')
+    @skipIf(latex_not_installed, '"lualatex" and "latexmk" are not installed.')
     @override_settings(BILLING_EXPORTERS=['creme.billing.exporters.latex.LatexExportEngine'])
     def test_exporter_latex(self):
         engine1 = LatexExportEngine(Quote)
@@ -885,7 +885,7 @@ class ExportTestCase(BrickTestCaseMixin, _BillingTestCase):
 
     @skipIfCustomInvoice
     @skipIfCustomProductLine
-    @skipIf(pdflatex_not_installed, '"pdflatex" is not installed.')
+    @skipIf(latex_not_installed, '"lualatex" and "latexmk" are not installed.')
     @override_settings(BILLING_EXPORTERS=['creme.billing.exporters.latex.LatexExportEngine'])
     def test_export_invoice_latex(self):
         user = self.login_as_root_and_get()
@@ -1322,7 +1322,7 @@ class ExportTestCase(BrickTestCaseMixin, _BillingTestCase):
 
     @skipIfCustomQuote
     @skipIfCustomServiceLine
-    @skipIf(pdflatex_not_installed, '"pdflatex" is not installed.')
+    @skipIf(latex_not_installed, '"lualatex" and "latexmk" are not installed.')
     @override_settings(BILLING_EXPORTERS=['creme.billing.exporters.latex.LatexExportEngine'])
     def test_export_quote_latex(self):
         user = self.login_as_root_and_get()
@@ -1524,7 +1524,7 @@ class ExportTestCase(BrickTestCaseMixin, _BillingTestCase):
 
         self.assertGET403(self._build_export_url(invoice))
 
-    @skipIf(pdflatex_not_installed, '"pdflatex" is not installed.')
+    @skipIf(latex_not_installed, '"lualatex" and "latexmk" are not installed.')
     @override_settings(BILLING_EXPORTERS=['creme.billing.exporters.latex.LatexExportEngine'])
     @skipIfCustomInvoice
     def test_export_latex_credentials01(self):
@@ -1550,7 +1550,7 @@ class ExportTestCase(BrickTestCaseMixin, _BillingTestCase):
         ).update(engine_id=LatexExportEngine.id)
         self.assertGET403(self._build_export_url(invoice))
 
-    @skipIf(pdflatex_not_installed, '"pdflatex" is not installed.')
+    @skipIf(latex_not_installed, '"lualatex" and "latexmk" are not installed.')
     @override_settings(BILLING_EXPORTERS=['creme.billing.exporters.latex.LatexExportEngine'])
     @skipIfCustomInvoice
     def test_export_latex_credentials02(self):

--- a/creme/settings.py
+++ b/creme/settings.py
@@ -1330,7 +1330,7 @@ BILLING_EXPORTERS = [
     'creme.billing.exporters.xls.XLSExportEngine',
     'creme.billing.exporters.xhtml2pdf.Xhtml2pdfExportEngine',
 
-    # You needed to install LateX on the server (the command "pdflatex" is run).
+    # You needed to install LateX on the server (the command "latexmk" and "lualatex" is run).
     # Some extra packages may be needed to render correctly the themes
     # (see FLAVOURS_INFO in 'creme/billing/exporters/latex.py')
     # 'creme.billing.exporters.latex.LatexExportEngine',


### PR DESCRIPTION
Thank you so much for making this software open source. I am still learning to use it and I am currently working on improving the LaTex backend to finally integrate Facture-X/Zugferd and Order-X into the billing backend.

I would  like to push those changes upstream as I progress if you are interested.

This PR starts with a small change to the LaTex backend replacing `pdflatex` with `lualatex` and `latexmk`. The latter has the following advantages over calling plain `pdflatex` or `lualatex`:

- `latexmk` will call tex multiple times if several passes are required by the tex engine.
- `latexmk` has the `-cd` flag which enters the temp directory during compilation and allows relative imports of auxiliary files like images (e.g. company logos or scanned signatures)

I chose to replace `pdflatex` with `lualatex` because `lualatex` offers a more modern backend with better utf-8 support. It also represent the current development direction instead of `pdflatex` which will see no new features added. This change will make generating compliant PDFs for Facture-X a lot easier later on.

The change from `lualatex` to  `pdflatex` changes the default Computer Modern font (or rather European Computer Modern when loading the T1 font using `fontenc`) used by  `pdflatex` to Latin Modern as this is a unicode compliant default font. Since the LaTex templates are demo templates I do not see an issue here.