### PR TITLE
Creme 2.6 UUID migration mapping

### DIFF
--- a/creme/billing/migrations/0034_v2_6__fix_uuids.py
+++ b/creme/billing/migrations/0034_v2_6__fix_uuids.py
@@ -1,5 +1,52 @@
 from django.db import migrations
 
+BILLING_PAYMENTTERMS_UUIDS = [
+    (1, '86b76130-4cac-4337-95ff-3e9021329956'),  # Deposit
+]
+
+BILLING_CREDITNOTESTATUS_UUIDS = [
+    (1, '57191226-8ece-4a7d-bb5f-1b9635f41d9b'),  # Draft
+    (2, '42263776-44e0-4b63-b330-9a0237ab37c8'),  # Issued
+    (3, '8fc73f0e-a427-4a07-b4f3-ae0b3eca9469'),  # Consumed
+    (4, '0eee82dd-fb06-4de0-acf9-4d1d4b970399'),  # Out of date
+]
+
+BILLING_INVOICESTATUS_UUIDS = [
+    (1, '1bbb7c7e-610f-4366-b3de-b92d63c9cf23'),  # Draft
+    (2, 'cc1209bb-e8a2-40bb-9361-4230d9e27bf2'),  # To be sent
+    (3, 'b8ed248b-5785-47ba-90d0-094ac9f813c7'),  # Sent
+    (4, '017e8734-533d-4fc7-b355-c091748ccb34'),  # Resulted
+    (5, '0d8da787-394c-4735-8cad-5eb3a2382415'),  # Partly resulted
+    (6, '134ed1ba-efce-4984-baae-dae06fa27096'),  # Collection
+    (7, 'b5b256bd-6205-4f67-af3b-eb76b47e97fa'),  # Resulted collection
+    (8, 'b85ad6ce-9479-4c70-9241-97c03774e521'),  # Canceled
+]
+
+BILLING_QUOTESTATUS_UUIDS = [
+    (1, '9128fed1-e87d-477b-aa94-3d220f724f05'),  # Pending
+    (2, 'aa5b25ec-ea70-470f-91a6-402dffe933a8'),  # Accepted
+    (3, '7739a6ac-64a7-4f40-a04d-39a382b08d50'),  # Rejected
+    (4, '9571e8bb-7a50-4453-a037-de829e189952'),  # Created
+]
+
+BILLING_SALESORDERSTATUS_UUIDS = [
+    (1, 'bebdab5a-0281-4b34-a257-26602a19e320'),  # Issued
+    (2, '717ac4a7-97f8-4002-a555-544e4427191a'),  # Accepted
+    (3, 'a91aa135-b075-4a81-a06b-dd1839954a71'),  # Rejected
+    (4, 'ee4dd8f7-557f-46d8-8ed2-74c256875b84'),  # Created
+]
+
+BILLING_SETTLEMENTTERMS_UUIDS = [
+    (1, '5d5db3d9-8af9-450a-9daa-67e78fae82f8'),  # 30 days
+    (2, '36590d27-bf69-43fc-bdb1-d3b13d1fac8e'),  # Cash
+    (3, '2d0540fa-8be0-474c-ae97-70d721d17ee3'),  # 45 days
+    (4, '3766296a-98ea-4341-a305-30e551d92550'),  # 60 days
+    (5, 'ad9152cb-bcb4-43ff-ba15-4b8d90557f23'),  # 30 days, end month the 10
+]
+
+BILLING_ADDITIONALINFORMATION_UUIDS = [
+    (1, '1c3c5157-1a42-4b88-9b78-de15b41bdd96'),  # Trainer accreditation
+]
 
 def _fix_uuids(apps, model_name, ids_to_uuids):
     filter_instances = apps.get_model('billing', model_name).objects.filter
@@ -29,83 +76,49 @@ def fix_payment_terms_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='PaymentTerms',
-        ids_to_uuids=[
-            (1, '86b76130-4cac-4337-95ff-3e9021329956'),  # Deposit
-        ],
+        ids_to_uuids=BILLING_PAYMENTTERMS_UUIDS,
     )
 
 def fix_cnote_statuses_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='CreditNoteStatus',
-        ids_to_uuids=[
-            (1, '57191226-8ece-4a7d-bb5f-1b9635f41d9b'),  # Draft
-            (2, '42263776-44e0-4b63-b330-9a0237ab37c8'),  # Issued
-            (3, '8fc73f0e-a427-4a07-b4f3-ae0b3eca9469'),  # Consumed
-            (4, '0eee82dd-fb06-4de0-acf9-4d1d4b970399'),  # Out of date
-        ],
+        ids_to_uuids=BILLING_CREDITNOTESTATUS_UUIDS,
     )
 
 def fix_invoice_statuses_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='InvoiceStatus',
-        ids_to_uuids=[
-            (1, '1bbb7c7e-610f-4366-b3de-b92d63c9cf23'),  # Draft
-            (2, 'cc1209bb-e8a2-40bb-9361-4230d9e27bf2'),  # To be sent
-            (3, 'b8ed248b-5785-47ba-90d0-094ac9f813c7'),  # Sent
-            (4, '017e8734-533d-4fc7-b355-c091748ccb34'),  # Resulted
-            (5, '0d8da787-394c-4735-8cad-5eb3a2382415'),  # Partly resulted
-            (6, '134ed1ba-efce-4984-baae-dae06fa27096'),  # Collection
-            (7, 'b5b256bd-6205-4f67-af3b-eb76b47e97fa'),  # Resulted collection
-            (8, 'b85ad6ce-9479-4c70-9241-97c03774e521'),  # Canceled
-        ],
+        ids_to_uuids=BILLING_INVOICESTATUS_UUIDS,
     )
 
 def fix_quote_statuses_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='QuoteStatus',
-        ids_to_uuids=[
-            (1, '9128fed1-e87d-477b-aa94-3d220f724f05'),  # Pending
-            (2, 'aa5b25ec-ea70-470f-91a6-402dffe933a8'),  # Accepted
-            (3, '7739a6ac-64a7-4f40-a04d-39a382b08d50'),  # Rejected
-            (4, '9571e8bb-7a50-4453-a037-de829e189952'),  # Created
-        ],
+        ids_to_uuids=BILLING_QUOTESTATUS_UUIDS,
     )
 
 def fix_order_statuses_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='SalesOrderStatus',
-        ids_to_uuids=[
-            (1, 'bebdab5a-0281-4b34-a257-26602a19e320'),  # Issued
-            (2, '717ac4a7-97f8-4002-a555-544e4427191a'),  # Accepted
-            (3, 'a91aa135-b075-4a81-a06b-dd1839954a71'),  # Rejected
-            (4, 'ee4dd8f7-557f-46d8-8ed2-74c256875b84'),  # Created
-        ],
+        ids_to_uuids=BILLING_SALESORDERSTATUS_UUIDS,
     )
 
 def fix_settlement_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='SettlementTerms',
-        ids_to_uuids=[
-            (1, '5d5db3d9-8af9-450a-9daa-67e78fae82f8'),  # 30 days
-            (2, '36590d27-bf69-43fc-bdb1-d3b13d1fac8e'),  # Cash
-            (3, '2d0540fa-8be0-474c-ae97-70d721d17ee3'),  # 45 days
-            (4, '3766296a-98ea-4341-a305-30e551d92550'),  # 60 days
-            (5, 'ad9152cb-bcb4-43ff-ba15-4b8d90557f23'),  # 30 days, end month the 10
-        ],
+        ids_to_uuids=BILLING_SETTLEMENTTERMS_UUIDS,
     )
 
 def fix_additional_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='AdditionalInformation',
-        ids_to_uuids=[
-            (1, '1c3c5157-1a42-4b88-9b78-de15b41bdd96'),  # Trainer accreditation
-        ],
+        ids_to_uuids=BILLING_ADDITIONALINFORMATION_UUIDS,
     )
 
 

--- a/creme/opportunities/migrations/0017_v2_6__fix_uuids.py
+++ b/creme/opportunities/migrations/0017_v2_6__fix_uuids.py
@@ -1,5 +1,25 @@
 from django.db import migrations
 
+OPPORTUNITIES_SALESPHASE_UUIDS = [
+    (1, '9fc5ff38-b358-4131-b03e-6c1f800bfb08'),  # Forthcoming
+    (2, '4445c750-bcec-4fcd-afb2-c9e35a3bf38c'),  # In progress
+    (3, 'aa59fcec-2dde-46e1-a362-c30c18386c19'),  # Under negotiation
+    (4, '779931a8-a2ed-47b1-96a1-8694452e9905'),  # Abandoned
+    (5, 'd8b5429f-89e5-46cc-9e53-5d1a0127f880'),  # Won
+    (6, '597d796e-a368-48f0-8dfb-56f16965792b'),  # Lost
+]
+
+OPPORTUNITIES_ORIGIN_UUIDS = [
+    (1, '814e485e-418a-42d5-a6ef-720aaffee7a0'),  # None
+    (2, '96f55fa8-df31-4d64-8f7e-c0b5f1ca0bc6'),  # Web site
+    (3, '0e914271-b162-4554-afae-837916378220'),  # Mouth
+    (4, '14d5bb2f-5ad7-46ab-a194-59f2bb105b66'),  # Show
+    (5, '0f23d337-7a64-4f22-9448-7c0d2df9891b'),  # Direct email
+    (6, 'b4e097b9-05c0-4fc9-8c12-bc62cf106046'),  # Direct phone call
+    (7, 'c8632a03-4b78-4c00-8e45-7b04bacab2e8'),  # Employee
+    (8, '9bb9012f-a4dd-4e4c-8fb8-65c2aaaea789'),  # Partner
+    (9, '4b0a0229-cd0d-400d-8fb5-29a1479c41fe'),  # Other
+]
 
 def _fix_uuids(apps, model_name, ids_to_uuids):
     filter_instances = apps.get_model('opportunities', model_name).objects.filter
@@ -29,14 +49,7 @@ def fix_sales_phases_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='SalesPhase',
-        ids_to_uuids=[
-            (1, '9fc5ff38-b358-4131-b03e-6c1f800bfb08'),  # Forthcoming
-            (2, '4445c750-bcec-4fcd-afb2-c9e35a3bf38c'),  # In progress
-            (3, 'aa59fcec-2dde-46e1-a362-c30c18386c19'),  # Under negotiation
-            (4, '779931a8-a2ed-47b1-96a1-8694452e9905'),  # Abandoned
-            (5, 'd8b5429f-89e5-46cc-9e53-5d1a0127f880'),  # Won
-            (6, '597d796e-a368-48f0-8dfb-56f16965792b'),  # Lost
-        ],
+        ids_to_uuids=OPPORTUNITIES_SALESPHASE_UUIDS,
     )
 
 
@@ -44,17 +57,7 @@ def fix_origins_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='Origin',
-        ids_to_uuids=[
-            (1, '814e485e-418a-42d5-a6ef-720aaffee7a0'),  # None
-            (2, '96f55fa8-df31-4d64-8f7e-c0b5f1ca0bc6'),  # Web site
-            (3, '0e914271-b162-4554-afae-837916378220'),  # Mouth
-            (4, '14d5bb2f-5ad7-46ab-a194-59f2bb105b66'),  # Show
-            (5, '0f23d337-7a64-4f22-9448-7c0d2df9891b'),  # Direct email
-            (6, 'b4e097b9-05c0-4fc9-8c12-bc62cf106046'),  # Direct phone call
-            (7, 'c8632a03-4b78-4c00-8e45-7b04bacab2e8'),  # Employee
-            (8, '9bb9012f-a4dd-4e4c-8fb8-65c2aaaea789'),  # Partner
-            (9, '4b0a0229-cd0d-400d-8fb5-29a1479c41fe'),  # Other
-        ],
+        ids_to_uuids=OPPORTUNITIES_ORIGIN_UUIDS,
     )
 
 

--- a/creme/persons/migrations/0034_v2_6__fix_uuids.py
+++ b/creme/persons/migrations/0034_v2_6__fix_uuids.py
@@ -1,5 +1,43 @@
 from django.db import migrations
 
+PERSONS_CIVILITY_UUIDS = [
+    (1, '7c3867da-af53-43d4-bfcc-75c1c3e5121e'),  # Madam
+    (2, '6b84a23d-c4ec-41c1-a35d-e6c0af5af2a0'),  # Miss
+    (3, '08e68afd-64aa-4981-a1db-4bde37b08655'),  # Mister
+    (4, '547504b3-a886-4837-9170-62f2bc706e7f'),  # N/A
+]
+
+PERSONS_POSITION_UUIDS = [
+    (1, '1534eb82-f55c-45ef-af2e-4e2d5d68218f'),  # CEO
+    (2, '7e10f7f8-730c-45b4-8e81-6b2e4cfbab36'),  # Secretary
+    (3, '9669e6a9-4661-4248-bc7c-d675f6e13216'),  # Technician
+]
+
+PERSONS_SECTOR_UUIDS = [
+    (1, '4995508b-069b-4ad5-a07d-9ae9c17918f2'),  # 'Food Industry
+    (2, '06581ce8-e5ab-4875-b18d-b1ae366a9073'),  # Industry
+    (3, 'd3d16967-b4e4-4dff-a401-c97ab36fa9a2'),  # Software
+    (4, '471ec83d-d7cc-4b51-8ff4-b3b16c339927'),  # Telecom
+    (5, '115ecac3-dda1-4388-ad8c-c1d4d6e86214'),  # Restoration
+]
+
+PERSONS_LEGALFORM_UUIDS = [
+    (1, '0f9ffebf-ae6a-4314-bf78-5ac33c477385'),  # SARL
+    (2, '97ec5342-cfcd-47f2-9977-03238a4bb815'),  # Association loi 1901
+    (3, '2a18cf05-19bd-47d1-96d0-7dd2ea969e74'),  # SA
+    (4, '2085dfac-9714-407c-972b-2256e8472124'),  # SAS
+]
+
+
+PERSONS_STAFFSIZE_UUIDS = [
+    (1, '625f5c71-db51-48f7-b548-63360d0b6653'),  # 1 - 5
+    (2, '405efcfb-b6cc-4996-8062-b0794d6b718b'),  # 6 - 10
+    (3, '57b8a9f0-b672-473a-bc77-db0cd73f4d71'),  # 11 - 50
+    (4, 'bab5348c-9a46-4a05-a72e-b94db229f818'),  # 51 - 100
+    (5, 'fd1a7587-624f-4cd1-adbc-309e237cfe91'),  # 100 - 500
+    (6, 'ca0a585c-a40d-480c-86d0-c9610c93b23b'),  # > 500
+]
+
 
 def _fix_uuids(apps, model_name, ids_to_uuids):
     filter_instances = apps.get_model('persons', model_name).objects.filter
@@ -28,36 +66,21 @@ def fix_civilities_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='Civility',
-        ids_to_uuids=[
-            (1, '7c3867da-af53-43d4-bfcc-75c1c3e5121e'),  # Madam
-            (2, '6b84a23d-c4ec-41c1-a35d-e6c0af5af2a0'),  # Miss
-            (3, '08e68afd-64aa-4981-a1db-4bde37b08655'),  # Mister
-            (4, '547504b3-a886-4837-9170-62f2bc706e7f'),  # N/A
-        ],
+        ids_to_uuids=PERSONS_CIVILITY_UUIDS,
     )
 
 def fix_positions_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='Position',
-        ids_to_uuids=[
-            (1, '1534eb82-f55c-45ef-af2e-4e2d5d68218f'),  # CEO
-            (2, '7e10f7f8-730c-45b4-8e81-6b2e4cfbab36'),  # Secretary
-            (3, '9669e6a9-4661-4248-bc7c-d675f6e13216'),  # Technician
-        ],
+        ids_to_uuids=PERSONS_POSITION_UUIDS,
     )
 
 def fix_sectors_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='Sector',
-        ids_to_uuids=[
-            (1, '4995508b-069b-4ad5-a07d-9ae9c17918f2'),  # 'Food Industry
-            (2, '06581ce8-e5ab-4875-b18d-b1ae366a9073'),  # Industry
-            (3, 'd3d16967-b4e4-4dff-a401-c97ab36fa9a2'),  # Software
-            (4, '471ec83d-d7cc-4b51-8ff4-b3b16c339927'),  # Telecom
-            (5, '115ecac3-dda1-4388-ad8c-c1d4d6e86214'),  # Restoration
-        ],
+        ids_to_uuids=PERSONS_SECTOR_UUIDS,
     )
 
 
@@ -65,26 +88,14 @@ def fix_legal_forms_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='LegalForm',
-        ids_to_uuids=[
-            (1, '0f9ffebf-ae6a-4314-bf78-5ac33c477385'),  # SARL
-            (2, '97ec5342-cfcd-47f2-9977-03238a4bb815'),  # Association loi 1901
-            (3, '2a18cf05-19bd-47d1-96d0-7dd2ea969e74'),  # SA
-            (4, '2085dfac-9714-407c-972b-2256e8472124'),  # SAS
-        ],
+        ids_to_uuids=PERSONS_LEGALFORM_UUIDS,
     )
 
 def fix_staff_sizes_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='StaffSize',
-        ids_to_uuids=[
-            (1, '625f5c71-db51-48f7-b548-63360d0b6653'),  # 1 - 5
-            (2, '405efcfb-b6cc-4996-8062-b0794d6b718b'),  # 6 - 10
-            (3, '57b8a9f0-b672-473a-bc77-db0cd73f4d71'),  # 11 - 50
-            (4, 'bab5348c-9a46-4a05-a72e-b94db229f818'),  # 51 - 100
-            (5, 'fd1a7587-624f-4cd1-adbc-309e237cfe91'),  # 100 - 500
-            (6, 'ca0a585c-a40d-480c-86d0-c9610c93b23b'),  # > 500
-        ],
+        ids_to_uuids=PERSONS_STAFFSIZE_UUIDS,
     )
 
 

--- a/creme/products/migrations/0015_v2_6__fix_categories_uuids.py
+++ b/creme/products/migrations/0015_v2_6__fix_categories_uuids.py
@@ -1,5 +1,45 @@
 from django.db import migrations
 
+PRODUCTS_CATEGORY_UUIDS = [
+    (1, '3fb0ef3c-45d0-40bd-8e71-b1ab49fca8d3'),  # Jewelry
+    (2, '74c91fab-d671-4054-984f-ba395d7dffcb'),  # Mobile
+    (3, '69084c8f-068c-41e3-80e3-42ed312e9815'),  # Electronics
+    (4, '213e14fa-bda1-4850-a22d-d3e6bb832a98'),  # Travels
+    (5, '684f4e8a-aad8-4eb5-980c-fbb8fc28776e'),  # Vehicle
+    (6, '8ef405ac-9109-4ea6-94eb-f068b33c617d'),  # Games & Toys
+    (7, '14474aee-9ba7-4a0e-816e-e19bab639af9'),  # Clothes
+]
+
+PRODUCTS_SUBCATEGORY_UUIDS = [
+    (1,  '2d6555fe-4c25-4098-8128-25395cf2c10b'),  # Ring
+    (2,  'c160d58f-6878-4dd6-87d6-ee05db310f3a'),  # Bracelet
+    (3,  '83b79894-122e-4212-bf18-929573f57c74'),  # Necklace
+    (4,  '6514cb2a-ee59-4abf-bdef-92488fac3a42'),  # Earrings
+    (5,  '2abfa34f-d30f-4629-9a45-8cd63ce0a362'),  # Iphone
+    (6,  '4c55bae2-44d3-44ca-aade-e8433339f2aa'),  # Blackberry
+    (7,  '5fc12768-bc62-4412-a9d4-91aa9967bfac'),  # Samsung
+    (8,  '62e549a1-f132-4c82-a836-e8d94ee8b29b'),  # Android
+    (9,  '25f7c8db-a0d1-42af-a342-97727a2229fd'),  # Laptops
+    (10, '6e3c21d1-f81e-492c-b2ce-da1fbc46727f'),  # Desktops
+    (11, '13463841-90df-4036-b830-62ad75668213'),  # Tablet
+    (12, '3a14d682-77b5-43b7-9b9c-8db9bcd44b0d'),  # Notebook
+    (13, '79c7d28f-eed2-4565-9815-1d1887f3ccaf'),  # Fly
+    (14, '9812ff36-b3f3-4670-8d4a-b8e9c916bf0d'),  # Hotel
+    (15, '15e6f072-bd3e-4591-9963-be2af1888520'),  # Weekend
+    (16, 'abaca40b-51c9-49c1-95c4-ba93e51bdc40'),  # Rent
+    (17, '7c3492c1-7621-456f-a849-1fc6af829435'),  # Car
+    (18, '1f5664c6-2a88-42d0-a554-e271dbe7fd84'),  # Bike
+    (19, '669d7604-0d71-48b1-aa4e-6ca52f8923f8'),  # Boat
+    (20, '886757aa-e019-4683-b83b-942ca9798e0b'),  # Plane
+    (21, 'f5f5efc4-b03e-47b9-b485-f85dfb1a2630'),  # Boys
+    (22, '39d811f7-707b-4419-8750-b15179d5b3eb'),  # Girls
+    (23, 'd92fd9d0-a8cd-4d6e-9d8c-24037a2121fe'),  # Teens
+    (24, 'dc8d1368-55d7-4abc-80c2-28ba1d3d1d3b'),  # Babies
+    (25, '01109ac2-e539-45fd-a2a8-b3fff7992933'),  # Men
+    (26, 'eaf8bc61-e1a1-4181-a679-84c606037922'),  # Women
+    (27, 'ecf095f8-f3a7-4271-921c-81b1dff714a6'),  # Kids
+    (28, 'ba170185-892e-400a-b212-1810fc86f204'),  # Babies
+]
 
 def _fix_uuids(apps, model_name, ids_to_uuids):
     filter_instances = apps.get_model('products', model_name).objects.filter
@@ -28,51 +68,14 @@ def fix_categories_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='Category',
-        ids_to_uuids=[
-            (1, '3fb0ef3c-45d0-40bd-8e71-b1ab49fca8d3'),  # Jewelry
-            (2, '74c91fab-d671-4054-984f-ba395d7dffcb'),  # Mobile
-            (3, '69084c8f-068c-41e3-80e3-42ed312e9815'),  # Electronics
-            (4, '213e14fa-bda1-4850-a22d-d3e6bb832a98'),  # Travels
-            (5, '684f4e8a-aad8-4eb5-980c-fbb8fc28776e'),  # Vehicle
-            (6, '8ef405ac-9109-4ea6-94eb-f068b33c617d'),  # Games & Toys
-            (7, '14474aee-9ba7-4a0e-816e-e19bab639af9'),  # Clothes
-        ],
+        ids_to_uuids=PRODUCTS_CATEGORY_UUIDS,
     )
 
 def fix_sub_categories_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='SubCategory',
-        ids_to_uuids=[
-            (1,  '2d6555fe-4c25-4098-8128-25395cf2c10b'),  # Ring
-            (2,  'c160d58f-6878-4dd6-87d6-ee05db310f3a'),  # Bracelet
-            (3,  '83b79894-122e-4212-bf18-929573f57c74'),  # Necklace
-            (4,  '6514cb2a-ee59-4abf-bdef-92488fac3a42'),  # Earrings
-            (5,  '2abfa34f-d30f-4629-9a45-8cd63ce0a362'),  # Iphone
-            (6,  '4c55bae2-44d3-44ca-aade-e8433339f2aa'),  # Blackberry
-            (7,  '5fc12768-bc62-4412-a9d4-91aa9967bfac'),  # Samsung
-            (8,  '62e549a1-f132-4c82-a836-e8d94ee8b29b'),  # Android
-            (9,  '25f7c8db-a0d1-42af-a342-97727a2229fd'),  # Laptops
-            (10, '6e3c21d1-f81e-492c-b2ce-da1fbc46727f'),  # Desktops
-            (11, '13463841-90df-4036-b830-62ad75668213'),  # Tablet
-            (12, '3a14d682-77b5-43b7-9b9c-8db9bcd44b0d'),  # Notebook
-            (13, '79c7d28f-eed2-4565-9815-1d1887f3ccaf'),  # Fly
-            (14, '9812ff36-b3f3-4670-8d4a-b8e9c916bf0d'),  # Hotel
-            (15, '15e6f072-bd3e-4591-9963-be2af1888520'),  # Weekend
-            (16, 'abaca40b-51c9-49c1-95c4-ba93e51bdc40'),  # Rent
-            (17, '7c3492c1-7621-456f-a849-1fc6af829435'),  # Car
-            (18, '1f5664c6-2a88-42d0-a554-e271dbe7fd84'),  # Bike
-            (19, '669d7604-0d71-48b1-aa4e-6ca52f8923f8'),  # Boat
-            (20, '886757aa-e019-4683-b83b-942ca9798e0b'),  # Plane
-            (21, 'f5f5efc4-b03e-47b9-b485-f85dfb1a2630'),  # Boys
-            (22, '39d811f7-707b-4419-8750-b15179d5b3eb'),  # Girls
-            (23, 'd92fd9d0-a8cd-4d6e-9d8c-24037a2121fe'),  # Teens
-            (24, 'dc8d1368-55d7-4abc-80c2-28ba1d3d1d3b'),  # Babies
-            (25, '01109ac2-e539-45fd-a2a8-b3fff7992933'),  # Men
-            (26, 'eaf8bc61-e1a1-4181-a679-84c606037922'),  # Women
-            (27, 'ecf095f8-f3a7-4271-921c-81b1dff714a6'),  # Kids
-            (28, 'ba170185-892e-400a-b212-1810fc86f204'),  # Babies
-        ],
+        ids_to_uuids=PRODUCTS_SUBCATEGORY_UUIDS,
     )
 
 

--- a/creme/projects/migrations/0028_v2_6__fix_statuses_uuids.py
+++ b/creme/projects/migrations/0028_v2_6__fix_statuses_uuids.py
@@ -24,33 +24,36 @@ def _fix_uuids(apps, model_name, ids_to_uuids):
             f'(old ones are stored in meta_data).'
         )
 
+PROJECTS_PROJECTSTATUS_UUIDS = [
+    (1, 'e0487a58-7c2a-45e9-a6da-f770c2f1bd53'),
+    (2, 'c065000b-51a8-4f73-8585-64893d30770f'),
+    (3, 'c9e3665d-2747-4ee9-a037-de751ae2a59a'),
+    (4, '680c049d-d01f-4835-aa92-dc1455ee2e9f'),
+    (5, '61d1f8dd-1849-4ec6-9cce-3b73e3f4d9ae'),
+    (6, '27d1c818-d7c7-4200-ac6e-744998cfa9b7'),
+    (7, 'a7d5caf2-c41c-4695-ab07-29300b2d19c1'),
+]
+
+PROJECTS_TASKSTATUS_UUIDS = [
+    (1, '23cea775-dfed-44d4-82c0-809708618798'),
+    (2, 'c05da59c-4a58-49b3-99af-c922c796caa7'),
+    (3, '0a345a07-9790-4278-ab1a-e568b90efd0e'),
+    (4, '35fbdfa6-d4ba-4f49-8e5f-60ccb6c4b8b2'),
+    (5, '2f74b370-a381-44cb-8e01-5bfc3ab4a8da'),
+]
 
 def fix_project_statuses_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='ProjectStatus',
-        ids_to_uuids=[
-            (1, 'e0487a58-7c2a-45e9-a6da-f770c2f1bd53'),
-            (2, 'c065000b-51a8-4f73-8585-64893d30770f'),
-            (3, 'c9e3665d-2747-4ee9-a037-de751ae2a59a'),
-            (4, '680c049d-d01f-4835-aa92-dc1455ee2e9f'),
-            (5, '61d1f8dd-1849-4ec6-9cce-3b73e3f4d9ae'),
-            (6, '27d1c818-d7c7-4200-ac6e-744998cfa9b7'),
-            (7, 'a7d5caf2-c41c-4695-ab07-29300b2d19c1'),
-        ],
+        ids_to_uuids=PROJECTS_PROJECTSTATUS_UUIDS,
     )
 
 def fix_task_statuses_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='TaskStatus',
-        ids_to_uuids=[
-            (1, '23cea775-dfed-44d4-82c0-809708618798'),
-            (2, 'c05da59c-4a58-49b3-99af-c922c796caa7'),
-            (3, '0a345a07-9790-4278-ab1a-e568b90efd0e'),
-            (4, '35fbdfa6-d4ba-4f49-8e5f-60ccb6c4b8b2'),
-            (5, '2f74b370-a381-44cb-8e01-5bfc3ab4a8da'),
-        ],
+        ids_to_uuids=PROJECTS_TASKSTATUS_UUIDS,
     )
 
 

--- a/creme/tickets/migrations/0015_v2_6__fix_uuids.py
+++ b/creme/tickets/migrations/0015_v2_6__fix_uuids.py
@@ -1,5 +1,29 @@
 from django.db import migrations
 
+TICKETS_STATUS_UUIDS = [
+    (1, '9c70ade9-1d84-41b4-8b80-73090590de20'),
+    (2, '7cb4d6d8-8fc8-4500-9941-becff6ce0dfc'),
+    (3, '367377a2-cacc-490c-8996-2170408ee202'),
+    (4, '004be181-1dac-4b53-9bb0-8b6dc6435c3d'),
+    (5, 'cfea0016-12f8-4a81-b659-b4cf07cdda0e'),
+]
+
+TICKETS_PRIORITY_UUIDS = [
+    (1, '87599d36-8133-41b7-a382-399d5e96b160'),
+    (2, '816cefa7-2f30-46a6-8baa-92e4647f44d3'),
+    (3, '42c39215-cf78-4d0b-b00b-b54a6680f71a'),
+    (4, '69bdbe35-cf99-4168-abb3-389aab6b7313'),
+    (5, 'd2dba4cb-382c-4d94-8306-4ec739f03144'),
+]
+
+TICKETS_CRITICITY_UUIDS = [
+    (1, '368a6b62-c66e-4286-b841-1062f59133c9'),
+    (2, '1aa05ca4-68ec-4068-ac3b-b9ddffaeb0aa'),
+    (3, 'e5a2a80e-36e8-49fd-8b2b-e802ccd4090c'),
+    (4, '9937c865-d0e7-4f33-92f3-600814e293ad'),
+    (5, '8e509e5e-8bd6-4cd0-8f96-5c129f0a875d'),
+    (6, '3bd07632-f3ad-415e-bb33-95c723e46aa5'),
+]
 
 def _fix_uuids(apps, model_name, ids_to_uuids):
     filter_instances = apps.get_model('tickets', model_name).objects.filter
@@ -28,40 +52,21 @@ def fix_statuses_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='Status',
-        ids_to_uuids=[
-            (1, '9c70ade9-1d84-41b4-8b80-73090590de20'),
-            (2, '7cb4d6d8-8fc8-4500-9941-becff6ce0dfc'),
-            (3, '367377a2-cacc-490c-8996-2170408ee202'),
-            (4, '004be181-1dac-4b53-9bb0-8b6dc6435c3d'),
-            (5, 'cfea0016-12f8-4a81-b659-b4cf07cdda0e'),
-        ],
+        ids_to_uuids=TICKETS_STATUS_UUIDS,
     )
 
 def fix_priorities_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='Priority',
-        ids_to_uuids=[
-            (1, '87599d36-8133-41b7-a382-399d5e96b160'),
-            (2, '816cefa7-2f30-46a6-8baa-92e4647f44d3'),
-            (3, '42c39215-cf78-4d0b-b00b-b54a6680f71a'),
-            (4, '69bdbe35-cf99-4168-abb3-389aab6b7313'),
-            (5, 'd2dba4cb-382c-4d94-8306-4ec739f03144'),
-        ],
+        ids_to_uuids=TICKETS_PRIORITY_UUIDS,
     )
 
 def fix_criticality_uuids(apps, schema_editor):
     _fix_uuids(
         apps,
         model_name='Criticity',
-        ids_to_uuids=[
-            (1, '368a6b62-c66e-4286-b841-1062f59133c9'),
-            (2, '1aa05ca4-68ec-4068-ac3b-b9ddffaeb0aa'),
-            (3, 'e5a2a80e-36e8-49fd-8b2b-e802ccd4090c'),
-            (4, '9937c865-d0e7-4f33-92f3-600814e293ad'),
-            (5, '8e509e5e-8bd6-4cd0-8f96-5c129f0a875d'),
-            (6, '3bd07632-f3ad-415e-bb33-95c723e46aa5'),
-        ],
+        ids_to_uuids=TICKETS_CRITICITY_UUIDS,
     )
 
 


### PR DESCRIPTION
The goal is to ease the uuid migration process for projects that declare static objects in code, or need to keep uuid consistants between multiple environment (i.e. local dev / staging / production)