### PR TITLE
Use resolve_url instead reverse in PermissionsMixin.get_login_uri

### DIFF
--- a/creme/creme_core/tests/views/test_main.py
+++ b/creme/creme_core/tests/views/test_main.py
@@ -17,6 +17,7 @@ from creme.creme_core.models import (
     Language,
 )
 from creme.creme_core.utils.media import get_creme_media_url
+from creme.creme_core.views.generic.base import PermissionsMixin
 from creme.creme_core.views.testjs import js_testview_or_404
 
 from ..base import CremeTestCase
@@ -40,6 +41,14 @@ class MiscViewsTestCase(CremeTestCase):
         f = BytesIO(b''.join(response.streaming_content))
         img = Image.open(f)
         self.assertEqual('PNG', img.format)
+
+    @override_settings(LOGIN_URL="/creme_login")
+    def test_get_login_uri(self):
+        mixin = PermissionsMixin()
+        request = RequestFactory().get('/')
+        mixin.request = request
+        with self.assertNoException():
+            mixin.get_login_uri()
 
     def test_about(self):
         self.login_as_root()

--- a/creme/creme_core/views/generic/base.py
+++ b/creme/creme_core/views/generic/base.py
@@ -32,7 +32,7 @@ from django.http import (
     HttpResponse,
     HttpResponseRedirect,
 )
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, resolve_url
 from django.urls import reverse, reverse_lazy
 from django.utils.html import escape
 from django.utils.translation import gettext
@@ -162,7 +162,7 @@ class PermissionsMixin:
         if not login_url_name:
             raise ImproperlyConfigured('Define settings.LOGIN_URL')
 
-        url = reverse(login_url_name)
+        url = resolve_url(login_url_name)
         redirect_arg_name = self.login_redirect_arg_name
 
         return '{}?{}'.format(


### PR DESCRIPTION
Django documentation for LOGIN_URL says for LOGIN_URL : "The URL or named URL pattern where requests are redirected for login". 

With reverse we can't provide a url and unfortunately providing a url may be necessary when we want to use a SSO. 