### PR TITLE
Fix empty tinymce field in popups.

### DIFF
--- a/creme/creme_core/static/creme_core/js/forms.js
+++ b/creme/creme_core/static/creme_core/js/forms.js
@@ -247,7 +247,10 @@ creme.forms.validateHtml5Form = function(form, options) {
          noValidate: options.noValidate || form.is('[novalidate]')
     };
 
-    $('input, select, textarea, datalist, output', form).each(function() {
+    var inputs = $('input, select, textarea, datalist, output', form);
+
+    inputs.filter(':not([type="submit"])').trigger('html5-pre-validate', [options]);
+    inputs.each(function() {
         $.extend(errors, creme.forms.validateHtml5Field($(this), fieldOptions));
     });
 

--- a/creme/creme_core/static/creme_core/js/tests/form/forms.js
+++ b/creme/creme_core/static/creme_core/js/tests/form/forms.js
@@ -276,6 +276,8 @@ QUnit.test('creme.forms.validateHtml5Form (no error)', function(assert) {
     var lastname = this.form.find('[name="lastname"]').on('html5-invalid', this.mockListener('lastname-invalid'));
     var email = this.form.find('[name="email"]').on('html5-invalid', this.mockListener('email-invalid'));
 
+    this.form.on('html5-pre-validate', 'input', this.mockListener('pre-validate'));
+
     lastname.val('Doe');
     email.val('john.doe@unknown.com');
 
@@ -291,7 +293,13 @@ QUnit.test('creme.forms.validateHtml5Form (no error)', function(assert) {
     deepEqual({
         'firstname-invalid': [['html5-invalid', [false]]],
         'lastname-invalid': [['html5-invalid', [false]]],
-        'email-invalid': [['html5-invalid', [false]]]
+        'email-invalid': [['html5-invalid', [false]]],
+        'pre-validate': [
+            ['html5-pre-validate', [{}]],
+            ['html5-pre-validate', [{}]],
+            ['html5-pre-validate', [{}]]
+            // ignore input[type="submit"] field
+        ]
     }, this.mockListenerJQueryCalls());
 });
 

--- a/creme/creme_core/static/creme_core/js/widgets/editor.js
+++ b/creme/creme_core/static/creme_core/js/widgets/editor.js
@@ -130,6 +130,14 @@ creme.widget.Editor = creme.widget.declare('ui-creme-editor', {
 
         editor.render();
 
+        this._onPreValidate = function() {
+            if (this._editor) {
+                this._editor.save();
+            }
+        }.bind(this);
+
+        element.on('html5-pre-validate', this._onPreValidate);
+
         creme.object.invoke(cb, element);
         element.addClass('widget-ready');
     },
@@ -138,6 +146,8 @@ creme.widget.Editor = creme.widget.declare('ui-creme-editor', {
         if (this._editor) {
             this._editor.remove();
         }
+
+        element.off('html5-pre-validate', this._onPreValidate);
     },
 
     editor: function(element) {

--- a/creme/creme_core/templates/creme_core/tests/test_frame.html
+++ b/creme/creme_core/templates/creme_core/tests/test_frame.html
@@ -357,7 +357,7 @@
             </div>
             <div class="popup-form-field">
                 <label for="comment">Comment</label>
-                <textarea name="comment" autofocus rows="4"></textarea>
+                <textarea widget="ui-creme-editor" name="comment" class="ui-creme-editor ui-creme-widget widget-auto" basepath="tiny_mce"></textarea>
             </div>
             <div class="popup-form-field">
                 <label for="image">Image</label>


### PR DESCRIPTION
The editor is waiting for a 'submit' event from the Form element that never occurs in popups. Instead a new 'html5-pre-validate' event will be send to force editor.save() and fill the field.