### PR TITLE
Remove a very old & ugly hack in our form-fields/widgets.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -84,6 +84,14 @@
             - Apps :
                 * Billing :
                     - The function 'utils.round_to_2()' has been removed.
+        # In 'creme_core.forms' :
+            - The method 'fields.JSONField.from_python()' has been removed; the classical Django method
+              'prepare_value()' has been implemented instead, & is used in child fields & related widgets.
+            - In 'mass_import' :
+                - The method 'RelationExtractor.create_if_unfound()' is now a simple boolean attribute;
+                  the attribute '_related_form' has been removed.
+                - The class 'RelationExtractorField' has been replaced by 'MultiRelationsExtractorField';
+                  the related widget & template have been heavily reworked too.
         # In 'creme_core.gui.bricks' :
             - The method 'Brick._simple_detailview_display()' has been removed.
             - In the class 'BrickRegistry':

--- a/creme/billing/tests/forms/test_export.py
+++ b/creme/billing/tests/forms/test_export.py
@@ -211,7 +211,8 @@ class ExporterLocalisationFieldTestCase(_BillingTestCase):
         field = ExporterLocalisationField(engine_manager=manager, model=Invoice)
 
         self.assertJSONEqual(
-            raw=field.from_python(('FR', 'fr_FR')),
+            # raw=field.from_python(('FR', 'fr_FR')),
+            raw=field.prepare_value(('FR', 'fr_FR')),
             expected_data={
                 'country': {
                     'country_code': 'FR',
@@ -230,7 +231,8 @@ class ExporterLocalisationFieldTestCase(_BillingTestCase):
         field = ExporterLocalisationField(engine_manager=manager, model=Invoice)
 
         self.assertJSONEqual(
-            raw=field.from_python(('FR', 'fr_FR')),
+            # raw=field.from_python(('FR', 'fr_FR')),
+            raw=field.prepare_value(('FR', 'fr_FR')),
             expected_data={
                 'country': {
                     'country_code': 'FR',

--- a/creme/creme_core/forms/fields.py
+++ b/creme/creme_core/forms/fields.py
@@ -127,12 +127,12 @@ class JSONField(fields.CharField):
     def __init__(self, *, user: CremeUser | None = None, **kwargs):
         super().__init__(**kwargs)
         self._user = user
-        self.widget.from_python = self.from_python
+        # self.widget.from_python = self.from_python
 
-    def __deepcopy__(self, memo):
-        obj = super().__deepcopy__(memo)
-        obj.widget.from_python = obj.from_python
-        return obj
+    # def __deepcopy__(self, memo):
+    #     obj = super().__deepcopy__(memo)
+    #     obj.widget.from_python = obj.from_python
+    #     return obj
 
     @property
     def user(self) -> CremeUser | None:
@@ -222,8 +222,15 @@ class JSONField(fields.CharField):
     def format_json(self, value):
         return json_encode(value)
 
-    # TODO: can we remove this hack with the new widget api (since django 1.2) ??
-    def from_python(self, value):
+    # def from_python(self, value):
+    #     if not value:
+    #         return ''
+    #
+    #     if isinstance(value, str):
+    #         return value
+    #
+    #     return self.format_json(self._value_to_jsonifiable(value))
+    def prepare_value(self, value):
         if not value:
             return ''
 

--- a/creme/creme_core/forms/mass_import.py
+++ b/creme/creme_core/forms/mass_import.py
@@ -31,8 +31,8 @@ from django.core.validators import EMPTY_VALUES
 from django.db import models
 from django.db.models import ManyToManyField, Model, prefetch_related_objects
 from django.db.transaction import atomic
+from django.forms import widgets
 from django.forms.models import modelform_factory
-from django.forms.widgets import HiddenInput, Widget
 from django.template.defaultfilters import slugify
 from django.urls import reverse_lazy as reverse
 from django.utils.html import format_html, format_html_join
@@ -124,7 +124,7 @@ def get_header(filedata, has_header):
 
 
 class UploadForm(CremeForm):
-    step = forms.IntegerField(widget=HiddenInput)
+    step = forms.IntegerField(widget=widgets.HiddenInput)
     document = core_fields.CreatorEntityField(
         label=_('File to import'),
         model=Document,
@@ -185,7 +185,7 @@ class SingleColumnExtractor(BaseExtractor):
         return self._column_index
 
 
-class BaseExtractorWidget(Widget):
+class BaseExtractorWidget(widgets.Widget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.column_select = PrettySelect()
@@ -788,25 +788,38 @@ class EntityExtractorField(forms.Field):
 # Extractors (and related field/widget) for relations---------------------------
 
 class RelationExtractor(SingleColumnExtractor):
-    def __init__(
-            self,
-            column_index: int,
-            rtype,
-            subfield_search,
-            related_model,
-            create_if_unfound):
+    # def __init__(
+    #         self,
+    #         column_index: int,
+    #         rtype,
+    #         subfield_search,
+    #         related_model,
+    #         create_if_unfound):
+    #     super().__init__(column_index=column_index)
+    #     self._rtype = rtype
+    #     self._subfield_search = str(subfield_search)
+    #     self._related_model = related_model
+    #     self._related_form = modelform_factory(
+    #         related_model, fields='__all__',
+    #     ) if create_if_unfound else None
+    # TODO: keyword-only arguments
+    def __init__(self,
+                 column_index: int,
+                 rtype: RelationType,
+                 subfield_search: str,
+                 related_model,
+                 create_if_unfound=False,
+                 ):
         super().__init__(column_index=column_index)
         self._rtype = rtype
         self._subfield_search = str(subfield_search)
         self._related_model = related_model
-        self._related_form = modelform_factory(
-            related_model, fields='__all__',
-        ) if create_if_unfound else None
+        self.create_if_unfound = create_if_unfound
 
     related_model = property(lambda self: self._related_model)
 
-    def create_if_unfound(self):
-        return self._related_form is not None
+    # def create_if_unfound(self):
+    #     return self._related_form is not None
 
     @property
     def rtype(self):
@@ -846,9 +859,13 @@ class RelationExtractor(SingleColumnExtractor):
                 )
             else:
                 if object_entity is None:
-                    if self._related_form:  # Try to create the referenced instance
+                    # if self._related_form:
+                    if self.create_if_unfound:  # Try to create the referenced instance
                         data['user'] = user.id
-                        creator = self._related_form(data=data)
+                        # creator = self._related_form(data=data)
+                        creator = modelform_factory(
+                            self._related_model, fields='__all__',
+                        )(data=data)
 
                         if creator.is_valid():
                             object_entity = creator.save()
@@ -891,20 +908,194 @@ class MultiRelationsExtractor:
         return iter(self._extractors)
 
 
-class RelationExtractorSelector(SelectorList):
-    template_name = 'creme_core/forms/widgets/mass-import/relations-extractor.html'
-
+# class RelationExtractorSelector(SelectorList):
+#     template_name = 'creme_core/forms/widgets/mass-import/relations-extractor.html'
+#
+#     def __init__(self, columns=(), relation_types=(), attrs=None):
+#         super().__init__(None, attrs=attrs)
+#         self.columns = columns
+#         self.relation_types = relation_types
+#
+#     def get_context(self, name, value, attrs):
+#         value = value or {}
+#         self.selector = chained_input = ChainedInput(attrs)
+#
+#         add_dselect = partial(
+#             chained_input.add_dselect,
+#             attrs={'auto': False, 'autocomplete': True},
+#             avoid_empty=True,
+#         )
+#         add_dselect(
+#             'rtype',
+#             options=self.relation_types, label=gettext('The entity'),
+#         )
+#         add_dselect(
+#             'ctype',
+#             options=TemplateURLBuilder(
+#                 rtype_id=(TemplateURLBuilder.Word, '${rtype}'),
+#             ).resolve('creme_core__ctypes_compatible_with_rtype'),
+#         )
+#         add_dselect(
+#             'searchfield',
+#             options=TemplateURLBuilder(
+#                 ct_id=(TemplateURLBuilder.Int, '${ctype}'),
+#             ).resolve('creme_core__entity_info_fields'),
+#             label=gettext('which field'),
+#         )
+#         add_dselect('column', options=self.columns, label=gettext('equals to'))
+#
+#         context = super().get_context(
+#             name=name,
+#             attrs=attrs,
+#             value=value.get('selectorlist'),
+#         )
+#         widget_cxt = context['widget']
+#         # SelectorList.get_context() does not use 'attrs' (to avoid duplicated "id"?)
+#         widget_cxt['attrs']['id'] = attrs.get('id') or f'id_{name}'
+#         widget_cxt['can_create_checked'] = value.get('can_create', False)
+#
+#         return context
+#
+#     def value_from_datadict(self, data, files, name):
+#         return {
+#             'selectorlist': super().value_from_datadict(
+#                 data=data, files=files, name=name,
+#             ),
+#             'can_create': data.get(f'{name}_can_create', False),
+#         }
+#
+#
+# class RelationExtractorField(core_fields.MultiRelationEntityField):
+#     widget = RelationExtractorSelector
+#     default_error_messages = {
+#         'fielddoesnotexist': _("This field doesn't exist in this ContentType."),
+#         'invalidcolunm':     _('This column is not a valid choice.'),
+#         'forbiddenctype': _(
+#             'The type «%(model)s» is not allowed by the relationship «%(predicate)s».'
+#         ),
+#     }
+#
+#     def __init__(self, *, columns=(), **kwargs):
+#         super().__init__(**kwargs)
+#         self.columns = columns
+#
+#     @property
+#     def columns(self):
+#         return self._columns
+#
+#     @columns.setter
+#     def columns(self, columns):
+#         self._columns = columns
+#         self.widget.columns = columns
+#
+#     def _value_to_jsonifiable(self, value):
+#         selectors = value['selectorlist']
+#         return {
+#             'selectorlist': [] if selectors is None else
+#               super()._value_to_jsonifiable(selectors),
+#             'can_create': value['can_create'],
+#         }
+#
+#     def clean(self, value):
+#         checked = value['can_create']
+#         selector_data = self.clean_json(value['selectorlist'])
+#
+#         if not selector_data:
+#             if self.required:
+#                 raise ValidationError(
+#                     self.error_messages['required'],
+#                     code='required',
+#                 )
+#
+#             return MultiRelationsExtractor([])
+#
+#         if not isinstance(selector_data, list):
+#             raise ValidationError(
+#                 self.error_messages['invalidformat'],
+#                 code='invalidformat',
+#             )
+#
+#         clean_value = self.clean_value
+#         cleaned_entries = [
+#             (
+#                 clean_value(entry, 'rtype',       str),
+#                 clean_value(entry, 'ctype',       int),
+#                 clean_value(entry, 'column',      int),
+#                 clean_value(entry, 'searchfield', str),
+#             ) for entry in selector_data
+#         ]
+#         extractors = []
+#         allowed_columns = frozenset(c[0] for c in self._columns)
+#         rtypes_by_id = self._clean_rtypes({entry[0] for entry in cleaned_entries})
+#
+#         prefetch_related_objects(
+#             [
+#                 single_rtype
+#                 for rtype in rtypes_by_id.values()
+#                 for single_rtype in (rtype, rtype.symmetric_type)
+#             ],
+#             'subject_ctypes',
+#             'subject_properties',
+#             'subject_forbidden_properties',
+#         )
+#
+#         for rtype_id, ctype_id, column, searchfield in cleaned_entries:
+#             if column not in allowed_columns:
+#                 raise ValidationError(
+#                     self.error_messages['invalidcolunm'],
+#                     params={'column': column},
+#                     code='invalidcolunm',
+#                 )
+#
+#             try:
+#                 ctype = ContentType.objects.get_for_id(ctype_id)
+#             except ContentType.DoesNotExist as e:
+#                 raise ValidationError(str(e)) from e
+#
+#             rtype = rtypes_by_id[rtype_id]
+#
+#             if not rtype.symmetric_type.is_compatible(ctype_id):
+#                 raise ValidationError(
+#                     message=self.error_messages['forbiddenctype'],
+#                     code='forbiddenctype',
+#                     params={
+#                         'model': ctype,
+#                         'predicate': rtype.symmetric_type.predicate,
+#                     },
+#                 )
+#
+#             model = ctype.model_class()
+#
+#             try:
+#                 model._meta.get_field(searchfield)
+#             except FieldDoesNotExist as e:
+#                 raise ValidationError(
+#                     self.error_messages['fielddoesnotexist'],
+#                     params={'field': searchfield},
+#                     code='fielddoesnotexist',
+#                 ) from e
+#
+#             extractors.append(RelationExtractor(
+#                 column_index=column,
+#                 rtype=rtype,
+#                 subfield_search=searchfield,
+#                 related_model=model,
+#                 create_if_unfound=checked,
+#             ))
+#
+#         return MultiRelationsExtractor(extractors)
+class BasicMultiRelationExtractorSelector(SelectorList):
     def __init__(self, columns=(), relation_types=(), attrs=None):
         super().__init__(None, attrs=attrs)
         self.columns = columns
         self.relation_types = relation_types
-        # TODO: autocomplete ?
+        # TODO: autocomplete?
 
     def get_context(self, name, value, attrs):
         value = value or {}
         self.selector = chained_input = ChainedInput(attrs)
 
-        # TODO: use GET args instead of using TemplateURLBuilders ?
+        # TODO: use GET args instead of using TemplateURLBuilders?
         add_dselect = partial(
             chained_input.add_dselect,
             attrs={'auto': False, 'autocomplete': True},
@@ -929,29 +1120,43 @@ class RelationExtractorSelector(SelectorList):
         )
         add_dselect('column', options=self.columns, label=gettext('equals to'))
 
-        context = super().get_context(
-            name=name,
-            attrs=attrs,
-            value=value.get('selectorlist'),
-        )
-        widget_cxt = context['widget']
-        # SelectorList.get_context() does not use 'attrs' (to avoid duplicated "id"?)
-        widget_cxt['attrs']['id'] = attrs.get('id') or f'id_{name}'
-        widget_cxt['can_create_checked'] = value.get('can_create', False)
+        return super().get_context(name=name, attrs=attrs, value=value)
 
-        return context
 
-    def value_from_datadict(self, data, files, name):
-        return {
-            'selectorlist': super().value_from_datadict(
-                data=data, files=files, name=name,
+class MultiRelationsExtractorSelector(widgets.MultiWidget):
+    template_name = 'creme_core/forms/widgets/mass-import/relations-extractor.html'
+
+    def __init__(self, columns=(), relation_types=(), attrs=None):
+        super().__init__(
+            widgets=(
+                widgets.CheckboxInput(attrs={'class': 'relationships_extractor-creation'}),
+                BasicMultiRelationExtractorSelector(columns=columns),  # TODO: relation types
             ),
-            'can_create': data.get(f'{name}_can_create', False),
-        }
+            attrs=attrs,
+        )
+
+    @property
+    def columns(self):
+        return self.widgets[1].columns
+
+    @columns.setter
+    def columns(self, columns):
+        self.widgets[1].columns = columns
+
+    @property
+    def relation_types(self):
+        return self.widgets[1].relation_types
+
+    @relation_types.setter
+    def relation_types(self, relation_types):
+        self.widgets[1].relation_types = relation_types
+
+    def decompress(self, value):
+        return (value[0], value[1]) if value else (False, None)
 
 
-class RelationExtractorField(core_fields.MultiRelationEntityField):
-    widget = RelationExtractorSelector
+class BasicMultiRelationsExtractorField(core_fields.MultiRelationEntityField):
+    widget = BasicMultiRelationExtractorSelector
     default_error_messages = {
         'fielddoesnotexist': _("This field doesn't exist in this ContentType."),
         'invalidcolunm':     _('This column is not a valid choice.'),
@@ -974,8 +1179,7 @@ class RelationExtractorField(core_fields.MultiRelationEntityField):
         self.widget.columns = columns
 
     def clean(self, value):
-        checked = value['can_create']
-        selector_data = self.clean_json(value['selectorlist'])
+        selector_data = self.clean_json(value)
 
         if not selector_data:
             if self.required:
@@ -1061,10 +1265,58 @@ class RelationExtractorField(core_fields.MultiRelationEntityField):
                 rtype=rtype,
                 subfield_search=searchfield,
                 related_model=model,
-                create_if_unfound=checked,
+                # create_if_unfound=False,
             ))
 
         return MultiRelationsExtractor(extractors)
+
+
+class MultiRelationsExtractorField(forms.MultiValueField):
+    widget = MultiRelationsExtractorSelector
+
+    def __init__(self, *,
+                 columns=(),
+                 allowed_rtypes=(),
+                 user=None,
+                 required=True,
+                 **kwargs):
+        super().__init__(
+            fields=(
+                forms.BooleanField(required=False),
+                BasicMultiRelationsExtractorField(required=required),
+            ),
+            require_all_fields=False,
+            required=required,
+            **kwargs
+        )
+        self.user = user  # TODO: property?
+        self.columns = columns
+        self.allowed_rtypes = allowed_rtypes
+
+    @property
+    def allowed_rtypes(self):
+        return self.fields[1].allowed_rtypes
+
+    @allowed_rtypes.setter
+    def allowed_rtypes(self, rtypes):
+        self.fields[1].allowed_rtypes = rtypes
+        self.widget.relation_types = self.fields[1]._get_options()
+
+    @property
+    def columns(self):
+        return self.fields[1].columns
+
+    @columns.setter
+    def columns(self, columns):
+        self.fields[1].columns = columns
+        self.widget.columns = columns
+
+    def compress(self, data_list):
+        can_create, extractor = data_list
+        for sub_extractor in extractor:
+            sub_extractor.create_if_unfound = can_create
+
+        return extractor
 
 
 # Extractors (and related field/widget) for custom fields ----------------------
@@ -1260,9 +1512,9 @@ class CustomfieldExtractorField(forms.Field):
 # TODO: merge with ImportForm4CremeEntity ?
 #  (no model that is not an entity is imported with csv...)
 class ImportForm(CremeModelForm):
-    step = forms.IntegerField(widget=HiddenInput)
-    document = forms.IntegerField(widget=HiddenInput)
-    has_header = forms.BooleanField(widget=HiddenInput, required=False)
+    step = forms.IntegerField(widget=widgets.HiddenInput)
+    document = forms.IntegerField(widget=widgets.HiddenInput)
+    has_header = forms.BooleanField(widget=widgets.HiddenInput, required=False)
     key_fields = forms.MultipleChoiceField(
         label=_('Key fields'), required=False,
         choices=(),
@@ -1536,7 +1788,8 @@ class ImportForm4CremeEntity(ImportForm):
     fixed_relations = core_fields.MultiRelationEntityField(
         label=_('Fixed relationships'), required=False, autocomplete=True,
     )
-    dyn_relations = RelationExtractorField(
+    # dyn_relations = RelationExtractorField(
+    dyn_relations = MultiRelationsExtractorField(
         label=_('Relationships from the file'), required=False,
     )
 
@@ -1599,8 +1852,8 @@ class ImportForm4CremeEntity(ImportForm):
         can_create = self.user.has_perm_to_create
 
         for extractor in extractors:
-            # if extractor.create_if_unfound and not can_create(extractor.related_model):
-            if extractor.create_if_unfound() and not can_create(extractor.related_model):
+            # if extractor.create_if_unfound() and not can_create(extractor.related_model):
+            if extractor.create_if_unfound and not can_create(extractor.related_model):
                 raise ValidationError(
                     self.error_messages['creation_forbidden'],
                     params={'model': model_verbose_name(extractor.related_model)},

--- a/creme/creme_core/forms/widgets.py
+++ b/creme/creme_core/forms/widgets.py
@@ -211,14 +211,12 @@ class DynamicSelect(EnhancedSelectOptions, widgets.Select):
         super().__init__(attrs, ())  # TODO: options or ()
         self.url = url
         self.label = label
-        self.from_python = None
+        # self.from_python = None
         self.choices = options
         self.avoid_empty = self.avoid_empty if avoid_empty is None else avoid_empty
 
     def get_context(self, name, value, attrs):
         widget_type = 'ui-creme-dselect'
-
-        # value = self.from_python(value) if self.from_python is not None else value # TODO ?
 
         context = super().get_context(name=name, value=value, attrs=attrs)
         widget_cxt = context['widget']
@@ -249,13 +247,11 @@ class DynamicSelectMultiple(EnhancedSelectOptions, widgets.SelectMultiple):
         super().__init__(attrs=attrs, choices=())  # TODO: options or ()
         self.url = url
         self.label = label
-        self.from_python = None
+        # self.from_python = None
         self.choices = options
 
     def get_context(self, name, value, attrs):
         widget_type = 'ui-creme-dselect'
-
-        # value = self.from_python(value) if self.from_python is not None else value  # TODO ?
 
         context = super().get_context(name=name, value=value, attrs=attrs)
         widget_cxt = context['widget']
@@ -285,7 +281,7 @@ class ActionButtonList(widgets.Widget):
         super().__init__(attrs)
         self.delegate = delegate
         self.actions = [*actions]
-        self.from_python = None
+        # self.from_python = None
 
     def __deepcopy__(self, memo):
         obj = super().__deepcopy__(memo)
@@ -309,7 +305,7 @@ class ActionButtonList(widgets.Widget):
     def get_context(self, name, value, attrs):
         widget_type = 'ui-creme-actionbuttonlist'
 
-        value = self.from_python(value) if self.from_python is not None else value
+        # value = self.from_python(value) if self.from_python is not None else value
 
         # TODO: what about attrs passed twice + cannot customise "class" of the wrapping <ul>?
         context = super().get_context(name=name, value=value, attrs=attrs)
@@ -334,7 +330,7 @@ class PolymorphicInput(widgets.TextInput):
         self.inputs = []
         self.default_input = None
         self.set_inputs(*args)
-        self.from_python = None  # TODO: remove this hack ?
+        # self.from_python = None
 
     def set_inputs(self, *args):
         for input in args:
@@ -360,7 +356,6 @@ class PolymorphicInput(widgets.TextInput):
     def get_context(self, name, value, attrs):
         widget_type = 'ui-creme-polymorphicselect'
 
-        # value = self.from_python(value) if self.from_python is not None else value # TODO ?
         context = super().get_context(name='', value='', attrs=attrs)
         widget_cxt = context['widget']
         widget_cxt['key'] = self.key
@@ -450,7 +445,7 @@ class ChainedInput(widgets.TextInput):
         super().__init__(attrs)
         self.inputs = []
         self.set_inputs(*args)
-        self.from_python = None  # TODO: remove this hack ?
+        # self.from_python = None
 
     def __deepcopy__(self, memo):
         obj = super().__deepcopy__(memo)
@@ -482,7 +477,7 @@ class ChainedInput(widgets.TextInput):
     def get_context(self, name, value, attrs):
         widget_type = 'ui-creme-chainedselect'
 
-        value = self.from_python(value) if self.from_python is not None else value
+        # value = self.from_python(value) if self.from_python is not None else value
         context = super().get_context(name=f'chain|{name}', value='', attrs=attrs)
         widget_cxt = context['widget']
         final_attrs = widget_cxt.pop('attrs')
@@ -522,7 +517,7 @@ class SelectorList(widgets.TextInput):
         self.selector = selector
 
         self.actions = [self.action_class(name='add', label=gettext_lazy('Add'), icon='add')]
-        self.from_python = None  # TODO: remove this hack ?
+        # self.from_python = None
 
     def add_action(self, name, label,
                    enabled=True, icon: str | None = None,
@@ -539,7 +534,7 @@ class SelectorList(widgets.TextInput):
     def get_context(self, name, value, attrs):
         widget_type = 'ui-creme-selectorlist'
 
-        value = self.from_python(value) if self.from_python is not None else value
+        # value = self.from_python(value) if self.from_python is not None else value
 
         context = super().get_context(name=name, value=value, attrs=attrs)
         widget_cxt = context['widget']
@@ -583,7 +578,7 @@ class EntitySelector(widgets.Widget):
         super().__init__(attrs=attrs)
         self.url = self._build_listview_url(content_type)
         self.text_url = self._build_text_url()
-        self.from_python = None
+        # self.from_python = None
 
     def _build_listview_url(self, content_type):
         return '{}?ct_id={}&selection=${{selection}}&q_filter=${{qfilter}}'.format(
@@ -599,8 +594,6 @@ class EntitySelector(widgets.Widget):
 
     def get_context(self, name, value, attrs):
         widget_type = 'ui-creme-entityselector'
-
-        # value = self.from_python(value) if self.from_python is not None else value  # TODO ?
 
         context = super().get_context(name=name, value=value, attrs=attrs)
         widget_cxt = context['widget']

--- a/creme/creme_core/templates/creme_core/forms/widgets/mass-import/relations-extractor.html
+++ b/creme/creme_core/templates/creme_core/forms/widgets/mass-import/relations-extractor.html
@@ -1,4 +1,17 @@
 {% load i18n %}
+{% with widgets=widget.subwidgets %}
+  {% with widget=widgets.0 %}
+  <label for="{{widget.attrs.id}}">
+     {% include widget.template_name %}
+     {% translate 'Create entities if they are not found? (only fields followed by [CREATION] allows you to create, if they exist)' %}
+  </label>
+  {% endwith %}
+
+  {% with widget=widgets.1 %}{% include widget.template_name %}{% endwith %}
+{% endwith %}
+
+{% comment %}
+{% load i18n %}
 {% with id=widget.attrs.id %}
 <label for="{{id}}_can_create">
     <input class="relationships_extractor-creation" type="checkbox" id="{{id}}_can_create" name="{{widget.name}}_can_create"{% if widget.can_create_checked %} checked{% endif %}/>
@@ -6,3 +19,4 @@
 </label>
 {% include 'creme_core/forms/widgets/selector-list.html' %}
 {% endwith %}
+{% endcomment %}

--- a/creme/creme_core/tests/forms/test_entity_filter.py
+++ b/creme/creme_core/tests/forms/test_entity_filter.py
@@ -390,7 +390,8 @@ class RegularFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
         )
 
         self.assertJSONEqual(
-            raw=field.from_python([condition]),
+            # raw=field.from_python([condition]),
+            raw=field.prepare_value([condition]),
             expected_data=[{
                 'field': {'name': name, 'type': 'string'},
                 'operator': {'id': operator, 'types': 'string'},
@@ -469,7 +470,8 @@ class RegularFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
         #         'value': True,
         #     }],
         # )
-        initial = json_load(field.from_python([condition]))
+        # initial = json_load(field.from_python([condition]))
+        initial = json_load(field.prepare_value([condition]))
         self.assertIsList(initial, length=1)
         initial0 = initial[0]
         self.assertIsDict(initial0, length=3)
@@ -522,7 +524,8 @@ class RegularFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
         #         'value': True,
         #     }],
         # )
-        initial = json_load(field.from_python([condition]))
+        # initial = json_load(field.from_python([condition]))
+        initial = json_load(field.prepare_value([condition]))
         self.assertIsList(initial, length=1)
         initial0 = initial[0]
         self.assertIsDict(initial0, length=3)
@@ -984,7 +987,8 @@ class RegularFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
 
         with self.assertLogs(level='WARNING') as logs_manager:
             with self.assertNoException():
-                raw_json = field.from_python([condition])
+                # raw_json = field.from_python([condition])
+                raw_json = field.prepare_value([condition])
         self.assertEqual('[]', raw_json)
 
         self.assertIn(
@@ -1385,7 +1389,8 @@ class DateFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
         )
 
         with self.assertNoException():
-            decoded_value = json_load(field.widget.from_python(field.initial))
+            # decoded_value = json_load(field.widget.from_python(field.initial))
+            decoded_value = json_load(field.prepare_value(field.initial))
 
         date_value = self.formfield_value_date
         self.assertListEqual(
@@ -1418,7 +1423,8 @@ class DateFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
 
         with self.assertLogs(level='WARNING') as logs_manager:
             with self.assertNoException():
-                raw_json = field.from_python([condition])
+                # raw_json = field.from_python([condition])
+                raw_json = field.prepare_value([condition])
         self.assertEqual('[]', raw_json)
 
         self.assertIn(
@@ -1492,7 +1498,8 @@ class CustomFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
         self.assertNotInChoices(value=self.cfield_datetime.id, choices=cfields)
         self.assertNotInChoices(value=self.cfield_date.id,     choices=cfields)
 
-    def test_from_python__custom_int(self):
+    # def test_from_python__custom_int(self):
+    def test_prepare_value__custom_int(self):
         EQUALS = operators.EQUALS
         field = CustomFieldsConditionsField(
             model=FakeContact, efilter_type=efilter_registry.id,
@@ -1512,7 +1519,8 @@ class CustomFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
             field._value_to_jsonifiable([condition]),
         )
 
-    def test_from_python__custom_string(self):
+    # def test_from_python__custom_string(self):
+    def test_prepare_value__custom_string(self):
         EQUALS = operators.EQUALS
         field = CustomFieldsConditionsField(
             model=FakeContact, efilter_type=efilter_registry.id,
@@ -1532,7 +1540,8 @@ class CustomFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
             field._value_to_jsonifiable([condition]),
         )
 
-    def test_from_python__custom_bool(self):
+    # def test_from_python__custom_bool(self):
+    def test_prepare_value__custom_bool(self):
         EQUALS = operators.EQUALS
         field = CustomFieldsConditionsField(
             model=FakeContact, efilter_type=efilter_registry.id,
@@ -1568,7 +1577,8 @@ class CustomFieldsConditionsFieldTestCase(_ConditionsFieldTestCase):
             field._value_to_jsonifiable([condition]),
         )
 
-    def test_from_python__custom_enum(self):
+    # def test_from_python__custom_enum(self):
+    def test_prepare_value__custom_enum(self):
         EQUALS = operators.EQUALS
         field = CustomFieldsConditionsField(
             model=FakeContact, efilter_type=efilter_registry.id,
@@ -2522,7 +2532,8 @@ class RelationsConditionsFieldTestCase(_ConditionsFieldTestCase):
                     'entity': None,
                 },
             ],
-            json_load(field.from_python(conditions)),
+            # json_load(field.from_python(conditions)),
+            json_load(field.prepare_value(conditions)),
         )
 
     def test_ok__fixed_content_type(self):
@@ -2567,7 +2578,8 @@ class RelationsConditionsFieldTestCase(_ConditionsFieldTestCase):
                     'entity': None,
                 },
             ],
-            json_load(field.from_python(conditions)),
+            # json_load(field.from_python(conditions)),
+            json_load(field.prepare_value(conditions)),
         )
 
     def test_ok__fixed_entity(self):
@@ -2595,7 +2607,8 @@ class RelationsConditionsFieldTestCase(_ConditionsFieldTestCase):
                 'ctype':  ct.id,
                 'entity': naru.id,
             }],
-            json_load(field.from_python(conditions)),
+            # json_load(field.from_python(conditions)),
+            json_load(field.prepare_value(conditions)),
         )
 
     def test_ok__fixed_ctype_n_entity(self):
@@ -2649,7 +2662,8 @@ class RelationsConditionsFieldTestCase(_ConditionsFieldTestCase):
         }
         self.assertListEqual(
             [jsondict],
-            json_load(field.from_python([*efilter.conditions.all()])),
+            # json_load(field.from_python([*efilter.conditions.all()])),
+            json_load(field.prepare_value([*efilter.conditions.all()])),
         )
 
         try:
@@ -2661,7 +2675,8 @@ class RelationsConditionsFieldTestCase(_ConditionsFieldTestCase):
         jsondict['ctype'] = 0
         self.assertListEqual(
             [jsondict],
-            json_load(field.from_python([*efilter.conditions.all()])),
+            # json_load(field.from_python([*efilter.conditions.all()])),
+            json_load(field.prepare_value([*efilter.conditions.all()])),
         )
 
     def test_ok__model_property(self):

--- a/creme/creme_core/tests/forms/test_json_fields.py
+++ b/creme/creme_core/tests/forms/test_json_fields.py
@@ -430,16 +430,19 @@ class JSONFieldTestCase(_JSONFieldBaseTestCase):
         self.assertValidationError(cm3.exception, messages=message, codes=code)
 
     def test_FMTing_to_json(self):
-        self.assertEqual('', JSONField().from_python(''))
+        # self.assertEqual('', JSONField().from_python(''))
+        self.assertEqual('', JSONField().prepare_value(''))
 
         val = 'this is a string'
-        self.assertEqual(val, JSONField().from_python(val))
+        # self.assertEqual(val, JSONField().from_python(val))
+        self.assertEqual(val, JSONField().prepare_value(val))
 
     def test_format_object_to_json(self):
         val = {'ctype': '12', 'entity': '1'}
         self.assertEqual(
             json_dump(val, separators=(',', ':')),
-            JSONField().from_python(val),
+            # JSONField().from_python(val),
+            JSONField().prepare_value(val),
         )
 
     # def test_clean_entity_from_model(self):  # DEPRECATED
@@ -565,7 +568,8 @@ class GenericEntityFieldTestCase(_JSONFieldBaseTestCase):
 
         self.assertEqual(
             self.build_field_data(12, 1, 'Add'),
-            field.from_python({
+            # field.from_python({
+            field.prepare_value({
                 'ctype': {
                     'create': reverse('creme_core__quick_form', args=(12,)),
                     'id': 12,
@@ -586,7 +590,8 @@ class GenericEntityFieldTestCase(_JSONFieldBaseTestCase):
                 },
                 'entity': contact.id,
             },
-            json_load(field.from_python(contact)),
+            # json_load(field.from_python(contact)),
+            json_load(field.prepare_value(contact)),
         )
 
         field.user = user
@@ -598,11 +603,14 @@ class GenericEntityFieldTestCase(_JSONFieldBaseTestCase):
             },
             'entity': contact.id,
         }
-        self.assertDictEqual(expected, json_load(field.from_python(contact)))
-        self.assertDictEqual(expected, json_load(field.from_python(contact.id)))
+        # self.assertDictEqual(expected, json_load(field.from_python(contact)))
+        # self.assertDictEqual(expected, json_load(field.from_python(contact.id)))
+        self.assertDictEqual(expected, json_load(field.prepare_value(contact)))
+        self.assertDictEqual(expected, json_load(field.prepare_value(contact.id)))
 
         with self.assertRaises(ValueError) as cm:
-            field.from_python(self.UNUSED_PK)
+            # field.from_python(self.UNUSED_PK)
+            field.prepare_value(self.UNUSED_PK)
         self.assertEqual(f'No such entity with id={self.UNUSED_PK}.', str(cm.exception))
 
     def test_format_ctype(self):
@@ -617,7 +625,8 @@ class GenericEntityFieldTestCase(_JSONFieldBaseTestCase):
                 },
                 'entity': None,
             },
-            json_load(field.from_python(ct)),
+            # json_load(field.from_python(ct)),
+            json_load(field.prepare_value(ct)),
         )
 
     def test_clean__empty__required(self):
@@ -970,7 +979,8 @@ class MultiGenericEntityFieldTestCase(_JSONFieldBaseTestCase):
                 build_entry_v1(contact_ct_id, 1, contact_label),
                 build_entry_v1(orga_ct_id, 5,    orga_label),
             ],
-            json_load(field.from_python([
+            # json_load(field.from_python([
+            json_load(field.prepare_value([
                 {
                     'ctype': {
                         'id': contact_ct_id,
@@ -1004,7 +1014,8 @@ class MultiGenericEntityFieldTestCase(_JSONFieldBaseTestCase):
                 build_entry_v2(contact_ct_id, contact.id, contact_label),
                 build_entry_v2(orga_ct_id,    orga.id,    orga_label),
             ],
-            json_load(field.from_python([contact, orga]))
+            # json_load(field.from_python([contact, orga]))
+            json_load(field.prepare_value([contact, orga]))
         )
 
         # With user
@@ -1024,7 +1035,8 @@ class MultiGenericEntityFieldTestCase(_JSONFieldBaseTestCase):
                 build_entry_v3(contact_ct_id, contact.id, contact_label),
                 build_entry_v3(orga_ct_id,    orga.id,    orga_label),
             ],
-            json_load(field.from_python([contact, orga])),
+            # json_load(field.from_python([contact, orga])),
+            json_load(field.prepare_value([contact, orga])),
         )
 
     def test_clean__empty__required(self):
@@ -2200,7 +2212,8 @@ class MultiRelationEntityFieldTestCase(_JSONFieldBaseTestCase):
 
         # TODO: assertJSONEqual ?
         with self.assertNoException():
-            json_data = json_load(field.from_python([(rtype1, contact), (rtype2, orga)]))
+            # json_data = json_load(field.from_python([(rtype1, contact), (rtype2, orga)]))
+            json_data = json_load(field.prepare_value([(rtype1, contact), (rtype2, orga)]))
 
         self.assertListEqual(
             [
@@ -2233,11 +2246,15 @@ class CreatorEntityFieldTestCase(_JSONFieldBaseTestCase):
 
     def test_format_object(self):
         contact = self.create_contact(user=self.get_root_user())
-        from_python = CreatorEntityField(model=FakeContact).from_python
         jsonified = str(contact.pk)
-        self.assertEqual(jsonified, from_python(jsonified))
-        self.assertEqual(jsonified, from_python(contact))
-        self.assertEqual(jsonified, from_python(contact.pk))
+        # from_python = CreatorEntityField(model=FakeContact).from_python
+        # self.assertEqual(jsonified, from_python(jsonified))
+        # self.assertEqual(jsonified, from_python(contact))
+        # self.assertEqual(jsonified, from_python(contact.pk))
+        prepare_value = CreatorEntityField(model=FakeContact).prepare_value
+        self.assertEqual(jsonified, prepare_value(jsonified))
+        self.assertEqual(jsonified, prepare_value(contact))
+        self.assertEqual(jsonified, prepare_value(contact.pk))
 
     def test_model(self):
         field = CreatorEntityField(model=FakeContact)
@@ -2303,11 +2320,14 @@ class CreatorEntityFieldTestCase(_JSONFieldBaseTestCase):
         field = CreatorEntityField(model=FakeContact)
 
         jsonified = str(contact.pk)
-        self.assertEqual(jsonified, field.from_python(jsonified))
-        self.assertEqual(jsonified, field.from_python(contact))
+        # self.assertEqual(jsonified, field.from_python(jsonified))
+        # self.assertEqual(jsonified, field.from_python(contact))
+        self.assertEqual(jsonified, field.prepare_value(jsonified))
+        self.assertEqual(jsonified, field.prepare_value(contact))
 
         with self.assertRaises(ValueError) as error:
-            field.from_python(orga.pk)
+            # field.from_python(orga.pk)
+            field.prepare_value(orga.pk)
 
         self.assertEqual(
             str(error.exception), f'No such entity with id={orga.id}.',
@@ -2641,12 +2661,17 @@ class MultiCreatorEntityFieldTestCase(_JSONFieldBaseTestCase):
         field = MultiCreatorEntityField(model=FakeContact)
         self.assertEqual(field.value_type, list)
 
-        from_python = field.from_python
         jsonified = f'[{contact.id}]'
-        self.assertEqual(jsonified, from_python(jsonified))
-        self.assertEqual(jsonified, from_python([contact]))
-        self.assertEqual(jsonified, from_python([contact.pk]))
-        self.assertEqual('', from_python([]))
+        # from_python = field.from_python
+        # self.assertEqual(jsonified, from_python(jsonified))
+        # self.assertEqual(jsonified, from_python([contact]))
+        # self.assertEqual(jsonified, from_python([contact.pk]))
+        # self.assertEqual('', from_python([]))
+        prepare_value = field.prepare_value
+        self.assertEqual(jsonified, prepare_value(jsonified))
+        self.assertEqual(jsonified, prepare_value([contact]))
+        self.assertEqual(jsonified, prepare_value([contact.pk]))
+        self.assertEqual('', prepare_value([]))
 
     def test_format_object_list(self):
         user = self.get_root_user()
@@ -2658,13 +2683,17 @@ class MultiCreatorEntityFieldTestCase(_JSONFieldBaseTestCase):
         field = MultiCreatorEntityField(model=FakeContact)
         self.assertEqual(field.value_type, list)
 
-        from_python = field.from_python
         jsonified = json_dump(
             [contact1.id, contact2.id, contact3.id], separators=(',', ':'),
         )
-        self.assertEqual(jsonified, from_python(jsonified))
-        self.assertEqual(jsonified, from_python([contact1, contact2, contact3]))
-        self.assertEqual(jsonified, from_python([contact1.pk, contact2.pk, contact3.pk]))
+        # from_python = field.from_python
+        # self.assertEqual(jsonified, from_python(jsonified))
+        # self.assertEqual(jsonified, from_python([contact1, contact2, contact3]))
+        # self.assertEqual(jsonified, from_python([contact1.pk, contact2.pk, contact3.pk]))
+        prepare_value = field.prepare_value
+        self.assertEqual(jsonified, prepare_value(jsonified))
+        self.assertEqual(jsonified, prepare_value([contact1, contact2, contact3]))
+        self.assertEqual(jsonified, prepare_value([contact1.pk, contact2.pk, contact3.pk]))
 
     def test_qfilter(self):
         contact = self.create_contact(user=self.get_root_user())
@@ -2695,15 +2724,19 @@ class MultiCreatorEntityFieldTestCase(_JSONFieldBaseTestCase):
         jsonified = json_dump(
             [contact1.id, contact2.id, contact3.id], separators=(',', ':'),
         )
-        self.assertEqual(jsonified, field.from_python(jsonified))
-        self.assertEqual(jsonified, field.from_python([contact1, contact2, contact3]))
+        # self.assertEqual(jsonified, field.from_python(jsonified))
+        # self.assertEqual(jsonified, field.from_python([contact1, contact2, contact3]))
+        self.assertEqual(jsonified, field.prepare_value(jsonified))
+        self.assertEqual(jsonified, field.prepare_value([contact1, contact2, contact3]))
         self.assertEqual(
             f'[{contact2.id},{contact3.id}]',
-            field.from_python([contact2.pk, contact3.pk])
+            # field.from_python([contact2.pk, contact3.pk])
+            field.prepare_value([contact2.pk, contact3.pk]),
         )
 
         with self.assertRaises(ValueError) as error:
-            field.from_python([contact1.pk, contact2.pk, contact3.pk])
+            # field.from_python([contact1.pk, contact2.pk, contact3.pk])
+            field.prepare_value([contact1.pk, contact2.pk, contact3.pk])
 
         ids = [str(e.id) for e in (contact1, contact2, contact3)]
         self.assertEqual(
@@ -2724,11 +2757,14 @@ class MultiCreatorEntityFieldTestCase(_JSONFieldBaseTestCase):
             [orga.id, contact1.id, contact2.id], separators=(',', ':'),
         )
 
-        self.assertEqual(jsonified, field.from_python(jsonified))
-        self.assertEqual(jsonified, field.from_python([orga, contact1, contact2]))
+        # self.assertEqual(jsonified, field.from_python(jsonified))
+        # self.assertEqual(jsonified, field.from_python([orga, contact1, contact2]))
+        self.assertEqual(jsonified, field.prepare_value(jsonified))
+        self.assertEqual(jsonified, field.prepare_value([orga, contact1, contact2]))
 
         with self.assertRaises(ValueError) as error:
-            field.from_python([orga.pk, contact1.pk, contact2.pk])
+            # field.from_python([orga.pk, contact1.pk, contact2.pk])
+            field.prepare_value([orga.pk, contact1.pk, contact2.pk])
 
         self.assertEqual(
             str(error.exception),

--- a/creme/creme_core/tests/forms/test_mass_import.py
+++ b/creme/creme_core/tests/forms/test_mass_import.py
@@ -8,6 +8,7 @@ from django.forms.widgets import TextInput
 from django.utils.translation import gettext as _
 
 from creme.creme_core.forms import CremeModelForm
+# RelationExtractorField, RelationExtractorSelector
 from creme.creme_core.forms.mass_import import (
     CustomFieldExtractor,
     CustomfieldExtractorField,
@@ -17,12 +18,12 @@ from creme.creme_core.forms.mass_import import (
     EntityExtractorField,
     EntityExtractorWidget,
     MultiRelationsExtractor,
+    MultiRelationsExtractorField,
+    MultiRelationsExtractorSelector,
     RegularFieldExtractor,
     RegularFieldExtractorField,
     RegularFieldExtractorWidget,
     RelationExtractor,
-    RelationExtractorField,
-    RelationExtractorSelector,
 )
 from creme.creme_core.models import (
     CustomField,
@@ -407,7 +408,8 @@ class RelationExtractorTestCase(CremeTestCase):
         self.assertEqual(column_index, extractor.column_index)
         self.assertEqual(rtype, extractor.rtype)
         self.assertEqual(field_name, extractor.subfield_search)
-        self.assertFalse(extractor.create_if_unfound())
+        # self.assertFalse(extractor.create_if_unfound())
+        self.assertFalse(extractor.create_if_unfound)
 
         self.assertTupleEqual(
             ((rtype, orga), None),
@@ -431,8 +433,30 @@ class RelationExtractorTestCase(CremeTestCase):
             create_if_unfound=True,
         )
         self.assertEqual(field_name, extractor.subfield_search)
-        self.assertTrue(extractor.create_if_unfound())
+        # self.assertTrue(extractor.create_if_unfound())
+        self.assertTrue(extractor.create_if_unfound)
 
+        extracted = extractor.extract_value([orga_name], user)
+        orga = self.get_object_or_fail(FakeOrganisation, name=orga_name)
+        self.assertTupleEqual(((rtype, orga), None), extracted)
+
+    def test_extract__create__property(self):
+        user = self.get_root_user()
+        rtype = self.rtype
+
+        orga_name = 'Acme'
+        self.assertFalse(FakeOrganisation.objects.filter(name=orga_name))
+
+        extractor = RelationExtractor(
+            column_index=1,
+            rtype=rtype,
+            subfield_search='name',
+            related_model=FakeOrganisation,
+            # create_if_unfound=True,
+        )
+        self.assertFalse(extractor.create_if_unfound)
+
+        extractor.create_if_unfound = True
         extracted = extractor.extract_value([orga_name], user)
         orga = self.get_object_or_fail(FakeOrganisation, name=orga_name)
         self.assertTupleEqual(((rtype, orga), None), extracted)
@@ -509,7 +533,6 @@ class RelationExtractorTestCase(CremeTestCase):
         )
 
     def test_extract__search__permissions(self):
-        # user = self.get_root_user()
         user = self.create_user(
             role=self.create_role(
                 allowed_apps=['creme_core'],
@@ -1097,7 +1120,259 @@ class EntityExtractorFieldTestCase(CremeTestCase):
         )
 
 
-class RelationExtractorFieldTestCase(CremeTestCase):
+# class RelationExtractorFieldTestCase(CremeTestCase):
+#     @classmethod
+#     def setUpClass(cls):
+#         super().setUpClass()
+#
+#         cls.rtype1 = RelationType.objects.builder(
+#             id='test-subject_employed_by', predicate='is an employee of',
+#             models=[FakeContact],
+#         ).symmetric(
+#             id='test-object_employed_by', predicate='employs',
+#             models=[FakeOrganisation],
+#         ).get_or_create()[0]
+#         cls.rtype2 = RelationType.objects.builder(
+#             id='test-subject_customer', predicate='is a customer of',
+#             models=[FakeContact, FakeOrganisation],
+#         ).symmetric(
+#             id='test-object_customer', predicate='is a supplier of',
+#             models=[FakeContact, FakeOrganisation],
+#         ).get_or_create()[0]
+#
+#     @staticmethod
+#     def _build_entry(*, rtype, model, column, subfield):
+#         return {
+#             'rtype':       rtype.id,
+#             'ctype':       str(ContentType.objects.get_for_model(model).id),
+#             'column':      str(column),
+#             'searchfield': subfield,
+#         }
+#
+#     @staticmethod
+#     def _build_data(can_create, *entries):
+#         return {
+#             'can_create': can_create,
+#             'selectorlist': json_dump([*entries]),
+#         }
+#
+#     def test_attributes(self):
+#         columns1 = [(1, 'Column #1'), (2, 'Column #2')]
+#         field = RelationExtractorField(columns=columns1)
+#         self.assertTrue(field.required)
+#         self.assertIsNone(field.user)
+#         self.assertListEqual(columns1, field.columns)
+#         self.assertFalse([*field.allowed_rtypes])
+#
+#         widget = field.widget
+#         self.assertIsInstance(field.widget, RelationExtractorSelector)
+#         self.assertListEqual(columns1, widget.columns)
+#         self.assertFalse([*widget.relation_types])
+#
+#         columns2 = [*columns1, (3, 'Column #3')]
+#         field.columns = columns2
+#         self.assertListEqual(columns2, field.columns)
+#         self.assertListEqual(columns2, widget.columns)
+#
+#     def test_clean__one_rtype(self):
+#         field = RelationExtractorField(
+#             columns=[(1, 'Column #1'), (2, 'Column #2')],
+#             allowed_rtypes=[self.rtype1.id, self.rtype2.id],
+#         )
+#
+#         fname = 'name'
+#         extractor = field.clean(
+#             self._build_data(
+#                 False,  # can_create
+#                 self._build_entry(
+#                     rtype=self.rtype1,
+#                     model=FakeOrganisation,
+#                     column=1,
+#                     subfield=fname,
+#                 ),
+#             ),
+#         )
+#         self.assertIsInstance(extractor, MultiRelationsExtractor)
+#
+#         extractors = [*extractor]
+#         self.assertEqual(1, len(extractors))
+#
+#         extractor = extractors[0]
+#         self.assertIsInstance(extractor, RelationExtractor)
+#         self.assertEqual(1,                extractor.column_index)
+#         self.assertEqual(self.rtype1,      extractor.rtype)
+#         self.assertEqual(FakeOrganisation, extractor.related_model)
+#         self.assertEqual(fname,            extractor.subfield_search)
+#         self.assertFalse(extractor.create_if_unfound())
+#
+#     def test_clean__two_rtypes(self):
+#         field = RelationExtractorField(
+#             columns=[(1, 'Column #1'), (2, 'Column #2'), (3, 'Column #3')],
+#             allowed_rtypes=[self.rtype1.id, self.rtype2.id],
+#         )
+#
+#         fname1 = 'name'
+#         fname2 = 'email'
+#         extractor1 = field.clean(
+#             self._build_data(
+#                 True,  # can_create
+#                 self._build_entry(
+#                     rtype=self.rtype1,
+#                     model=FakeOrganisation,
+#                     column=1,
+#                     subfield=fname1,
+#                 ),
+#                 self._build_entry(
+#                     rtype=self.rtype2,
+#                     model=FakeContact,
+#                     column=3,
+#                     subfield=fname2,
+#                 ),
+#             ),
+#         )
+#
+#         extractors = [*extractor1]
+#         self.assertEqual(2, len(extractors))
+#
+#         extractor1 = extractors[0]
+#         self.assertEqual(1,                extractor1.column_index)
+#         self.assertEqual(self.rtype1,      extractor1.rtype)
+#         self.assertEqual(FakeOrganisation, extractor1.related_model)
+#         self.assertEqual(fname1,           extractor1.subfield_search)
+#         self.assertTrue(extractor1.create_if_unfound())
+#
+#         extractor2 = extractors[1]
+#         self.assertEqual(3,           extractor2.column_index)
+#         self.assertEqual(self.rtype2, extractor2.rtype)
+#         self.assertEqual(FakeContact, extractor2.related_model)
+#         self.assertEqual(fname2,      extractor2.subfield_search)
+#         self.assertTrue(extractor2.create_if_unfound())
+#
+#     def test_clean__empty(self):
+#         field = RelationExtractorField(
+#             columns=[(1, 'Column #1'), (2, 'Column #2')],
+#             allowed_rtypes=[self.rtype1.id, self.rtype2.id],
+#             required=False,
+#         )
+#         self.assertFalse(field.required)
+#
+#         data = self._build_data(False)
+#         extractor = field.clean(data)
+#         self.assertIsInstance(extractor, MultiRelationsExtractor)
+#         self.assertFalse([*extractor])
+#
+#         # ---
+#         field.required = True
+#         self.assertFormfieldError(
+#             field=field,
+#             messages=_('This field is required.'),
+#             codes='required',
+#             value=data,
+#         )
+#
+#     def test_clean__invalid_data_type(self):
+#         self.assertFormfieldError(
+#             field=RelationExtractorField(
+#                 columns=[(1, 'Column #1'), (2, 'Column #2')],
+#                 allowed_rtypes=[self.rtype1.id],
+#                 required=False,
+#             ),
+#             value={
+#                 'can_create': False,
+#                 'selectorlist': json_dump({'foo': 'bar'}),  # <==
+#             },
+#             messages=_('Invalid format'),
+#             codes='invalidformat',
+#         )
+#
+#     def test_clean__forbidden_column(self):
+#         self.assertFormfieldError(
+#             field=RelationExtractorField(
+#                 columns=[(1, 'Column #1'), (2, 'Column #2')],
+#                 allowed_rtypes=[self.rtype1.id],
+#                 required=False,
+#             ),
+#             value=self._build_data(
+#                 False,  # can_create
+#                 self._build_entry(
+#                     rtype=self.rtype1,
+#                     model=FakeOrganisation,
+#                     column=3,  # <==
+#                     subfield='name',
+#                 ),
+#             ),
+#             messages=_('This column is not a valid choice.'),
+#             codes='invalidcolunm',
+#         )
+#
+#     def test_clean__invalid_search_field(self):
+#         self.assertFormfieldError(
+#             field=RelationExtractorField(
+#                 columns=[(1, 'Column #1'), (2, 'Column #2')],
+#                 allowed_rtypes=[self.rtype1.id],
+#                 required=False,
+#             ),
+#             value=self._build_data(
+#                 False,  # can_create
+#                 self._build_entry(
+#                     rtype=self.rtype1,
+#                     model=FakeOrganisation,
+#                     column=1,
+#                     subfield='invalid_field',   # <==
+#                 ),
+#             ),
+#             messages=_("This field doesn't exist in this ContentType."),
+#             codes='fielddoesnotexist',
+#         )
+#
+#     def test_clean__incompatible_ctype(self):
+#         self.assertFormfieldError(
+#             field=RelationExtractorField(
+#                 columns=[(1, 'Column #1'), (2, 'Column #2')],
+#                 allowed_rtypes=[self.rtype1.id],
+#                 required=False,
+#             ),
+#             value=self._build_data(
+#                 False,  # can_create
+#                 self._build_entry(
+#                     rtype=self.rtype1,
+#                     model=FakeDocument,  # <==
+#                     column=1,
+#                     subfield='title',
+#                 ),
+#             ),
+#             messages=_(
+#                 'The type «%(model)s» is not allowed by the relationship «%(predicate)s».'
+#             ) % {
+#                 'model': FakeDocument._meta.verbose_name,
+#                 'predicate': self.rtype1.symmetric_type.predicate,
+#             },
+#             codes='forbiddenctype',
+#         )
+#
+#     def test_clean__forbidden_rtype(self):
+#         self.assertFormfieldError(
+#             field=RelationExtractorField(
+#                 columns=[(1, 'Column #1'), (2, 'Column #2')],
+#                 allowed_rtypes=[self.rtype1.id],
+#                 required=False,
+#             ),
+#             value=self._build_data(
+#                 False,  # can_create
+#                 self._build_entry(
+#                     rtype=self.rtype2,
+#                     model=FakeDocument,  # <==
+#                     column=1,
+#                     subfield='title',
+#                 ),
+#             ),
+#             messages=_(
+#                 'This type of relationship causes a constraint error '
+#                 '(id="%(rtype_id)s").'
+#             ) % {'rtype_id': self.rtype2.id},
+#             codes='rtypenotallowed',
+#         )
+class MultiRelationsExtractorFieldTestCase(CremeTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -1128,21 +1403,21 @@ class RelationExtractorFieldTestCase(CremeTestCase):
 
     @staticmethod
     def _build_data(can_create, *entries):
-        return {
-            'can_create': can_create,
-            'selectorlist': json_dump([*entries]),
-        }
+        return [
+            'on' if can_create else '',
+            json_dump([*entries]),
+        ]
 
     def test_attributes(self):
         columns1 = [(1, 'Column #1'), (2, 'Column #2')]
-        field = RelationExtractorField(columns=columns1)
+        field = MultiRelationsExtractorField(columns=columns1)
         self.assertTrue(field.required)
         self.assertIsNone(field.user)
         self.assertListEqual(columns1, field.columns)
         self.assertFalse([*field.allowed_rtypes])
 
         widget = field.widget
-        self.assertIsInstance(field.widget, RelationExtractorSelector)
+        self.assertIsInstance(field.widget, MultiRelationsExtractorSelector)
         self.assertListEqual(columns1, widget.columns)
         self.assertFalse([*widget.relation_types])
 
@@ -1151,11 +1426,21 @@ class RelationExtractorFieldTestCase(CremeTestCase):
         self.assertListEqual(columns2, field.columns)
         self.assertListEqual(columns2, widget.columns)
 
+        rtypes = [self.rtype1, self.rtype2]
+        field.allowed_rtypes = [rtype.id for rtype in rtypes]
+        self.assertCountEqual(rtypes, field.allowed_rtypes)
+
+        choices = widget.relation_types
+        self.assertEqual(2, len(choices))
+        self.assertInChoices(value=self.rtype1.id, label=str(self.rtype1), choices=choices)
+        self.assertInChoices(value=self.rtype2.id, label=str(self.rtype2), choices=choices)
+
     def test_clean__one_rtype(self):
-        field = RelationExtractorField(
+        field = MultiRelationsExtractorField(
             columns=[(1, 'Column #1'), (2, 'Column #2')],
             allowed_rtypes=[self.rtype1.id, self.rtype2.id],
         )
+        self.assertCountEqual([self.rtype1, self.rtype2], field.allowed_rtypes)
 
         fname = 'name'
         extractor = field.clean(
@@ -1180,10 +1465,10 @@ class RelationExtractorFieldTestCase(CremeTestCase):
         self.assertEqual(self.rtype1,      extractor.rtype)
         self.assertEqual(FakeOrganisation, extractor.related_model)
         self.assertEqual(fname,            extractor.subfield_search)
-        self.assertFalse(extractor.create_if_unfound())
+        self.assertFalse(extractor.create_if_unfound)
 
     def test_clean__two_rtypes(self):
-        field = RelationExtractorField(
+        field = MultiRelationsExtractorField(
             columns=[(1, 'Column #1'), (2, 'Column #2'), (3, 'Column #3')],
             allowed_rtypes=[self.rtype1.id, self.rtype2.id],
         )
@@ -1216,55 +1501,59 @@ class RelationExtractorFieldTestCase(CremeTestCase):
         self.assertEqual(self.rtype1,      extractor1.rtype)
         self.assertEqual(FakeOrganisation, extractor1.related_model)
         self.assertEqual(fname1,           extractor1.subfield_search)
-        self.assertTrue(extractor1.create_if_unfound())
+        self.assertTrue(extractor1.create_if_unfound)
 
         extractor2 = extractors[1]
         self.assertEqual(3,           extractor2.column_index)
         self.assertEqual(self.rtype2, extractor2.rtype)
         self.assertEqual(FakeContact, extractor2.related_model)
         self.assertEqual(fname2,      extractor2.subfield_search)
-        self.assertTrue(extractor2.create_if_unfound())
+        self.assertTrue(extractor2.create_if_unfound)
 
-    def test_clean__empty(self):
-        field = RelationExtractorField(
+    def test_clean__empty__not_required(self):
+        field = MultiRelationsExtractorField(
             columns=[(1, 'Column #1'), (2, 'Column #2')],
             allowed_rtypes=[self.rtype1.id, self.rtype2.id],
             required=False,
         )
         self.assertFalse(field.required)
 
-        data = self._build_data(False)
-        extractor = field.clean(data)
+        extractor = field.clean(self._build_data(False))
         self.assertIsInstance(extractor, MultiRelationsExtractor)
         self.assertFalse([*extractor])
 
-        # ---
-        field.required = True
+    def test_clean__empty__required(self):
+        field = MultiRelationsExtractorField(
+            columns=[(1, 'Column #1'), (2, 'Column #2')],
+            allowed_rtypes=[self.rtype1.id, self.rtype2.id],
+            # required=True,
+        )
+        self.assertTrue(field.required)
         self.assertFormfieldError(
             field=field,
             messages=_('This field is required.'),
             codes='required',
-            value=data,
+            value=self._build_data(False),
         )
 
     def test_clean__invalid_data_type(self):
         self.assertFormfieldError(
-            field=RelationExtractorField(
+            field=MultiRelationsExtractorField(
                 columns=[(1, 'Column #1'), (2, 'Column #2')],
                 allowed_rtypes=[self.rtype1.id],
                 required=False,
             ),
-            value={
-                'can_create': False,
-                'selectorlist': json_dump({'foo': 'bar'}),  # <==
-            },
+            value=[
+                '',
+                json_dump({'foo': 'bar'}),  # <==
+            ],
             messages=_('Invalid format'),
             codes='invalidformat',
         )
 
     def test_clean__forbidden_column(self):
         self.assertFormfieldError(
-            field=RelationExtractorField(
+            field=MultiRelationsExtractorField(
                 columns=[(1, 'Column #1'), (2, 'Column #2')],
                 allowed_rtypes=[self.rtype1.id],
                 required=False,
@@ -1284,7 +1573,7 @@ class RelationExtractorFieldTestCase(CremeTestCase):
 
     def test_clean__invalid_search_field(self):
         self.assertFormfieldError(
-            field=RelationExtractorField(
+            field=MultiRelationsExtractorField(
                 columns=[(1, 'Column #1'), (2, 'Column #2')],
                 allowed_rtypes=[self.rtype1.id],
                 required=False,
@@ -1304,7 +1593,7 @@ class RelationExtractorFieldTestCase(CremeTestCase):
 
     def test_clean__incompatible_ctype(self):
         self.assertFormfieldError(
-            field=RelationExtractorField(
+            field=MultiRelationsExtractorField(
                 columns=[(1, 'Column #1'), (2, 'Column #2')],
                 allowed_rtypes=[self.rtype1.id],
                 required=False,
@@ -1329,7 +1618,7 @@ class RelationExtractorFieldTestCase(CremeTestCase):
 
     def test_clean__forbidden_rtype(self):
         self.assertFormfieldError(
-            field=RelationExtractorField(
+            field=MultiRelationsExtractorField(
                 columns=[(1, 'Column #1'), (2, 'Column #2')],
                 allowed_rtypes=[self.rtype1.id],
                 required=False,

--- a/creme/creme_core/tests/forms/test_widgets.py
+++ b/creme/creme_core/tests/forms/test_widgets.py
@@ -1433,7 +1433,7 @@ class EntityCreatorWidgetTestCase(CremeTestCase):
         )
         self.assertEqual(creation_label, widget.creation_label)
 
-        widget.from_python = lambda value: value.id
+        # widget.from_python = lambda value: value.id
         reset_label = _('Clear')
         html = '''
 <ul class="hbox ui-creme-widget ui-layout widget-auto ui-creme-actionbuttonlist"
@@ -1474,7 +1474,8 @@ class EntityCreatorWidgetTestCase(CremeTestCase):
 
             value=contact.id,
         )
-        self.assertHTMLEqual(html, widget.render('field', value=contact))
+        # self.assertHTMLEqual(html, widget.render('field', value=contact))
+        self.assertHTMLEqual(html, widget.render('field', value=contact.id))
 
 
 class CremeTextareaTestCase(CremeTestCase):

--- a/creme/creme_core/tests/forms/test_workflows.py
+++ b/creme/creme_core/tests/forms/test_workflows.py
@@ -174,7 +174,8 @@ class RelationAddingTriggerFieldTestCase(CremeTestCase):
                 'rtype': rtype1.id,
                 'ctype': ContentType.objects.get_for_model(model2).id,
             },
-            json_load(field1.from_python(trigger1)),
+            # json_load(field1.from_python(trigger1)),
+            json_load(field1.prepare_value(trigger1)),
         )
 
         # ---
@@ -426,11 +427,17 @@ class SourceFieldsTestCase(CremeTestCase):
         })
         self.assertEqual(FixedEntitySource(entity=orga), field.clean(serialized_data))
 
-        self.assertEqual('', field.from_python(None))
-        self.assertEqual('', field.from_python(''))
-        self.assertEqual(serialized_data, field.from_python(serialized_data))
+        # self.assertEqual('', field.from_python(None))
+        # self.assertEqual('', field.from_python(''))
+        # self.assertEqual(serialized_data, field.from_python(serialized_data))
+        # self.assertJSONEqual(
+        #     serialized_data, field.from_python(FixedEntitySource(entity=orga)),
+        # )
+        self.assertEqual('', field.prepare_value(None))
+        self.assertEqual('', field.prepare_value(''))
+        self.assertEqual(serialized_data, field.prepare_value(serialized_data))
         self.assertJSONEqual(
-            serialized_data, field.from_python(FixedEntitySource(entity=orga)),
+            serialized_data, field.prepare_value(FixedEntitySource(entity=orga)),
         )
 
     def test_FixedEntitySourceField__empty(self):
@@ -535,7 +542,8 @@ class FirstRelatedEntitySourceFieldTestCase(CremeTestCase):
                 'rtype': rtype1.id,
                 'ctype': ContentType.objects.get_for_model(model2).id,
             },
-            json_load(field1.from_python(source1)),
+            # json_load(field1.from_python(source1)),
+            json_load(field1.prepare_value(source1)),
         )
 
         # ---
@@ -855,11 +863,27 @@ class SourceFieldTestCase(CremeTestCase):
             (created_kind, {created_kind: ''}),
             field.prepare_value(CreatedEntitySource(model=model)),
         )
-        self.assertTupleEqual(
-            # TODO: to be fixed when prepare_value() is cleanly managed by our JSONFields...
-            (fixed_kind, {fixed_kind: FixedEntitySource(entity=orga)}),
-            field.prepare_value(FixedEntitySource(entity=orga)),
+
+        # self.assertTupleEqual(
+        #     (fixed_kind, {fixed_kind: FixedEntitySource(entity=orga)}),
+        #     field.prepare_value(FixedEntitySource(entity=orga)),
+        # )
+        fixed_prepared_value = field.prepare_value(FixedEntitySource(entity=orga))
+        self.assertIsTuple(fixed_prepared_value, length=2)
+        self.assertEqual(fixed_kind, fixed_prepared_value[0])
+        self.assertIsDict(fixed_prepared_value[1], length=1)
+        self.assertJSONEqual(
+            raw=fixed_prepared_value[1].get(fixed_kind),
+            expected_data={
+                'ctype': {
+                    'create': reverse('creme_core__quick_form', args=(orga.entity_type_id,)),
+                    'id': orga.entity_type_id,
+                    'create_label': str(orga.creation_label),
+                },
+                'entity': orga.id,
+            },
         )
+
         self.assertTupleEqual(
             (fk_kind, {fk_kind: 'image'}),
             field.prepare_value(EntityFKSource(

--- a/creme/creme_core/tests/views/test_mass_import.py
+++ b/creme/creme_core/tests/views/test_mass_import.py
@@ -88,7 +88,9 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
 
         # 'property_types',
         # 'fixed_relations',
-        # 'dyn_relations',
+        # # 'dyn_relations',
+        'dyn_relations_0': '',
+        'dyn_relations_1': '[]',
 
         'address_value_colselect':      0,
         'address_zipcode_colselect':    0,
@@ -365,7 +367,11 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 'property_types': [ptype1.id],
 
                 'fixed_relations': self.formfield_value_multi_relation_entity((loves, shinji)),
-                'dyn_relations': self._dyn_relations_value(
+                # 'dyn_relations': self._dyn_relations_value(
+                #     employed, FakeOrganisation, 6, 'name',
+                # ),
+                'dyn_relations_0': '',
+                'dyn_relations_1': self._dyn_relations_value(
                     employed, FakeOrganisation, 6, 'name',
                 ),
 
@@ -447,8 +453,14 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 'document': doc.id,
                 'user': user.id,
 
-                'dyn_relations': self._dyn_relations_value(employed, FakeOrganisation, 3, 'name'),
-                'dyn_relations_can_create': True,
+                # 'dyn_relations': self._dyn_relations_value(
+                #   employed, FakeOrganisation, 3, 'name'),
+                # 'dyn_relations_can_create': True,
+                'dyn_relations_0': 'on',
+                'dyn_relations_1': self._dyn_relations_value(
+                    rtype=employed, model=FakeOrganisation, column=3, subfield='name'
+                ),
+
             },
         )
         self.assertNoFormError(response)
@@ -624,7 +636,8 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 'document': doc.id,
                 'user': user.id,
                 'fixed_relations': self.formfield_value_multi_relation_entity((employed, nerv)),
-                'dyn_relations': self._dyn_relations_value(
+                # 'dyn_relations': self._dyn_relations_value(
+                'dyn_relations_1': self._dyn_relations_value(
                     employed, FakeOrganisation, 3, 'name',
                 ),
             },
@@ -690,7 +703,8 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 **self.lv_import_data,
                 'document': doc.id,
                 'user': user.id,
-                'dyn_relations': json_dump([
+                # 'dyn_relations': json_dump([
+                'dyn_relations_1': json_dump([
                     {
                         'rtype': employed.id,
                         'ctype': orga_ct_id,
@@ -829,7 +843,8 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 **self.lv_import_data,
                 'document': doc.id,
                 'user': user.id,
-                'dyn_relations': self._dyn_relations_value(
+                # 'dyn_relations': self._dyn_relations_value(
+                'dyn_relations_1': self._dyn_relations_value(
                     employed, FakeOrganisation, 3, 'name',
                 ),
             },
@@ -875,7 +890,8 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 'document': doc.id,
                 'user': user.id,
                 'property_types': [ptype.id],
-                'dyn_relations': self._dyn_relations_value(
+                # 'dyn_relations': self._dyn_relations_value(
+                'dyn_relations_1': self._dyn_relations_value(
                     employed, FakeOrganisation, 3, 'name',
                 ),
             },
@@ -941,7 +957,8 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 **self.lv_import_data,
                 'document': doc.id,
                 'user': user.id,
-                'dyn_relations': json_dump([
+                # 'dyn_relations': json_dump([
+                'dyn_relations_1': json_dump([
                     {
                         'rtype': employed.id,
                         'ctype': orga_ct_id,
@@ -1077,7 +1094,8 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 'document': doc.id,
                 'user': user.id,
                 'property_types': [ptype.id],
-                'dyn_relations': self._dyn_relations_value(
+                # 'dyn_relations': self._dyn_relations_value(
+                'dyn_relations_1': self._dyn_relations_value(
                     employed, FakeOrganisation, 3, 'name',
                 ),
             },
@@ -1127,7 +1145,8 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 'document': doc.id,
                 'user': user.id,
                 'property_types': [ptype2.id],
-                'dyn_relations': self._dyn_relations_value(
+                # 'dyn_relations': self._dyn_relations_value(
+                'dyn_relations_1': self._dyn_relations_value(
                     employed, FakeOrganisation, 3, 'name',
                 ),
             },
@@ -1847,8 +1866,13 @@ class MassImportViewsTestCase(MassImportBaseTestCaseMixin,
                 'first_name_colselect': 2,
                 'last_name_colselect': 1,
 
-                'dyn_relations': self._dyn_relations_value(employed, FakeOrganisation, 3, 'name'),
-                'dyn_relations_can_create': True,
+                # 'dyn_relations': self._dyn_relations_value(
+                #   employed, FakeOrganisation, 3, 'name'),
+                # 'dyn_relations_can_create': True,
+                'dyn_relations_0': True,
+                'dyn_relations_1': self._dyn_relations_value(
+                    rtype=employed, model=FakeOrganisation, column=3, subfield='name',
+                ),
             },
         )
         self.assertFormError(

--- a/creme/creme_core/tests/views/test_merge.py
+++ b/creme/creme_core/tests/views/test_merge.py
@@ -332,16 +332,16 @@ class MergeTestCase(CremeTestCase):
         create_img(name='Genshiken logo')  # Should not be proposed by the form
 
         create_contact = partial(FakeContact.objects.create, user=user)
-        contact01 = create_contact(first_name='Makoto', last_name='Kosaka',  image=image1)
-        contact02 = create_contact(first_name='Makoto', last_name='Kousaka', image=image2)
+        contact1 = create_contact(first_name='Makoto', last_name='Kosaka',  image=image1)
+        contact2 = create_contact(first_name='Makoto', last_name='Kousaka', image=image2)
 
         language1, language2 = Language.objects.all()[:2]
         language3 = Language.objects.create(name='Klingon')  # code='KLN'
 
-        contact01.languages.set([language1])
-        contact02.languages.set([language1, language2])
+        contact1.languages.set([language1])
+        contact2.languages.set([language1, language2])
 
-        url = self.build_merge_url(contact01, contact02)
+        url = self.build_merge_url(contact1, contact2)
         response1 = self.assertGET200(url)
 
         with self.assertNoException():
@@ -350,7 +350,8 @@ class MergeTestCase(CremeTestCase):
             languages_f = fields['languages']
 
         self.assertFalse(image_f.required)
-        self.assertEqual([image1.id,  image2.id,  image1.id],  image_f.initial)
+        # self.assertEqual([image1.id,  image2.id,  image1.id],  image_f.initial)
+        self.assertEqual([f'{image1.id}', f'{image2.id}', f'{image1.id}'],  image_f.initial)
 
         self.assertFalse(languages_f.required)
         self.assertListEqual(
@@ -374,13 +375,13 @@ class MergeTestCase(CremeTestCase):
                 'user_2':      user.id,
                 'user_merged': user.id,
 
-                'first_name_1':      contact01.first_name,
-                'first_name_2':      contact02.first_name,
-                'first_name_merged': contact01.first_name,
+                'first_name_1':      contact1.first_name,
+                'first_name_2':      contact2.first_name,
+                'first_name_merged': contact1.first_name,
 
-                'last_name_1':      contact01.last_name,
-                'last_name_2':      contact02.last_name,
-                'last_name_merged': contact01.last_name,
+                'last_name_1':      contact1.last_name,
+                'last_name_2':      contact2.last_name,
+                'last_name_merged': contact1.last_name,
 
                 'languages_1':      [language1.id],
                 'languages_2':      [language1.id, language2.id],
@@ -392,13 +393,13 @@ class MergeTestCase(CremeTestCase):
             },
         )
         self.assertNoFormError(response2)
-        self.assertRedirects(response2, contact01.get_absolute_url())
+        self.assertRedirects(response2, contact1.get_absolute_url())
 
-        self.assertDoesNotExist(contact02)
+        self.assertDoesNotExist(contact2)
 
-        new_contact01 = self.refresh(contact01)
-        self.assertEqual(contact01.first_name, new_contact01.first_name)
-        self.assertEqual(contact01.last_name,  new_contact01.last_name)
+        new_contact01 = self.refresh(contact1)
+        self.assertEqual(contact1.first_name, new_contact01.first_name)
+        self.assertEqual(contact1.last_name,  new_contact01.last_name)
         self.assertListEqual([language3],      [*new_contact01.languages.all()])
         self.assertEqual(image2,               new_contact01.image)
 

--- a/creme/creme_core/views/mass_import.py
+++ b/creme/creme_core/views/mass_import.py
@@ -1,6 +1,6 @@
 ################################################################################
 #    Creme is a free/open-source Customer Relationship Management software
-#    Copyright (C) 2009-2025  Hybird
+#    Copyright (C) 2009-2026  Hybird
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published by
@@ -118,8 +118,8 @@ def mass_import(request, ct_id):
 
     return render(
         request,
-        'creme_core/generics/blockform/add.html',
-        {
+        template_name='creme_core/generics/blockform/add.html',
+        context={
             'form': form,
             'title': _('Import «{model}» from data file').format(
                 model=model_verbose_name_plural(model),

--- a/creme/reports/tests/forms/test_chart.py
+++ b/creme/reports/tests/forms/test_chart.py
@@ -797,7 +797,8 @@ class AbscissaFieldTestCase(AxisFieldsMixin, CremeTestCase):
         self.assertEqual(chart_type, abs_info.chart_type)
         self.assertIsNone(abs_info.parameter)
 
-    def test_from_python__rfield__fk(self):
+    # def test_from_python__rfield__fk(self):
+    def test_preppare_value__rfield__fk(self):
         field = AbscissaField(
             model=FakeOrganisation, abscissa_constraints=abscissa_constraints,
         )
@@ -815,16 +816,22 @@ class AbscissaFieldTestCase(AxisFieldsMixin, CremeTestCase):
                 },
                 'parameter': '',
             },
-            json_load(field.from_python(
+            # json_load(field.from_python(
+            json_load(field.prepare_value(
                 AbscissaInfo(cell=cell, chart_type=chart_type)
             )),
         )
 
-    def test_from_python__rfield__date(self):
-        from_python = AbscissaField(
+    # def test_from_python__rfield__date(self):
+    def test_prepare_value__rfield__date(self):
+        # from_python = AbscissaField(
+        #     model=FakeOrganisation,
+        #     abscissa_constraints=abscissa_constraints,
+        # ).from_python
+        prepare_value = AbscissaField(
             model=FakeOrganisation,
             abscissa_constraints=abscissa_constraints,
-        ).from_python
+        ).prepare_value
         cell = EntityCellRegularField.build(FakeOrganisation, 'creation_date')
 
         chart_type1 = ReportChart.Group.YEAR
@@ -840,7 +847,8 @@ class AbscissaFieldTestCase(AxisFieldsMixin, CremeTestCase):
                 },
                 'parameter': '',
             },
-            json_load(from_python(AbscissaInfo(cell=cell, chart_type=chart_type1))),
+            # json_load(from_python(AbscissaInfo(cell=cell, chart_type=chart_type1))),
+            json_load(prepare_value(AbscissaInfo(cell=cell, chart_type=chart_type1))),
         )
 
         chart_type2 = ReportChart.Group.RANGE
@@ -857,12 +865,14 @@ class AbscissaFieldTestCase(AxisFieldsMixin, CremeTestCase):
                 },
                 'parameter': parameter,
             },
-            json_load(from_python(AbscissaInfo(
+            # json_load(from_python(AbscissaInfo(
+            json_load(prepare_value(AbscissaInfo(
                 cell=cell, chart_type=chart_type2, parameter=parameter,
             ))),
         )
 
-    def test_from_python__relation(self):
+    # def test_from_python__relation(self):
+    def test_prepare_value__relation(self):
         field = AbscissaField(
             model=FakeOrganisation, abscissa_constraints=abscissa_constraints,
         )
@@ -881,12 +891,14 @@ class AbscissaFieldTestCase(AxisFieldsMixin, CremeTestCase):
                 },
                 'parameter': '',
             },
-            json_load(field.from_python(
+            # json_load(field.from_python(
+            json_load(field.prepare_value(
                 AbscissaInfo(cell=cell, chart_type=chart_type)
             )),
         )
 
-    def test_from_python__cfield__enum(self):
+    # def test_from_python__cfield__enum(self):
+    def test_prepare_value__cfield__enum(self):
         model = FakeContact
         cfield = CustomField.objects.create(
             content_type=model,
@@ -909,12 +921,14 @@ class AbscissaFieldTestCase(AxisFieldsMixin, CremeTestCase):
                 },
                 'parameter': '',
             },
-            json_load(field.from_python(
+            # json_load(field.from_python(
+            json_load(field.prepare_value(
                 AbscissaInfo(cell=cell, chart_type=chart_type)
             )),
         )
 
-    def test_from_python__cfield__date(self):
+    # def test_from_python__cfield__date(self):
+    def test_prepapre_value__cfield__date(self):
         model = FakeContact
         cfield = CustomField.objects.create(
             content_type=model,
@@ -937,7 +951,8 @@ class AbscissaFieldTestCase(AxisFieldsMixin, CremeTestCase):
                 },
                 'parameter': '',
             },
-            json_load(field.from_python(
+            # json_load(field.from_python(
+            json_load(field.prepare_value(
                 AbscissaInfo(cell=cell, chart_type=chart_type))
             ),
         )
@@ -1339,7 +1354,8 @@ class OrdinateFieldTestCase(AxisFieldsMixin, CremeTestCase):
 
         # TODO: test empty choices ??
 
-    def test_from_python__count(self):
+    # def test_from_python__count(self):
+    def test_prepare_value__count(self):
         field = OrdinateField(
             model=FakeOrganisation,
             ordinate_constraints=ordinate_constraints,
@@ -1353,10 +1369,12 @@ class OrdinateFieldTestCase(AxisFieldsMixin, CremeTestCase):
                 },
                 'entity_cell': None,
             },
-            json_load(field.from_python(OrdinateInfo(aggr_id=aggr_id))),
+            # json_load(field.from_python(OrdinateInfo(aggr_id=aggr_id))),
+            json_load(field.prepare_value(OrdinateInfo(aggr_id=aggr_id))),
         )
 
-    def test_from_python__rfield__int(self):
+    # def test_from_python__rfield__int(self):
+    def test_prepare_value__rfield__int(self):
         field = OrdinateField(
             model=FakeOrganisation,
             ordinate_constraints=ordinate_constraints,
@@ -1375,10 +1393,12 @@ class OrdinateFieldTestCase(AxisFieldsMixin, CremeTestCase):
                     'aggr_category': category,
                 },
             },
-            json_load(field.from_python(OrdinateInfo(aggr_id=aggr_id, cell=cell))),
+            # json_load(field.from_python(OrdinateInfo(aggr_id=aggr_id, cell=cell))),
+            json_load(field.prepare_value(OrdinateInfo(aggr_id=aggr_id, cell=cell))),
         )
 
-    def test_from_python__cfield__int(self):
+    # def test_from_python__cfield__int(self):
+    def test_prepare_value__cfield__int(self):
         model = FakeContact
         cfield = CustomField.objects.create(
             content_type=model,
@@ -1403,7 +1423,8 @@ class OrdinateFieldTestCase(AxisFieldsMixin, CremeTestCase):
                     'aggr_category': category,
                 },
             },
-            json_load(field.from_python(OrdinateInfo(aggr_id=aggr_id, cell=cell))),
+            # json_load(field.from_python(OrdinateInfo(aggr_id=aggr_id, cell=cell))),
+            json_load(field.prepare_value(OrdinateInfo(aggr_id=aggr_id, cell=cell))),
         )
 
 # TODO: test ReportChartForm


### PR DESCRIPTION
The method 'JSONField.from_python()' has been removed & the classical Django method 'prepare_value()' is used instead.